### PR TITLE
Improve Firebase settings validation feedback

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,7 +1,12 @@
 import { FormEvent, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppState } from '../state/AppStateContext';
-import { initializeFirebase, resetFirebase, validateFirebaseConfig } from '../services/firebase';
+import {
+  initializeFirebase,
+  looksLikeServiceAccountConfig,
+  resetFirebase,
+  validateFirebaseConfig
+} from '../services/firebase';
 import {
   DEFAULT_OPENAI_BASE_URL,
   DEFAULT_OPENAI_MODEL,
@@ -27,6 +32,12 @@ function SettingsPage() {
     try {
       const normalizedConfig = firebaseConfig.trim();
       const parsed = normalizedConfig ? JSON.parse(normalizedConfig) : undefined;
+      if (parsed && looksLikeServiceAccountConfig(parsed)) {
+        setFeedback(
+          'O JSON fornecido parece ser uma credencial de Service Account. Obtenha a configuração Web do Firebase (apiKey, authDomain, projectId, …) na consola do Firebase.'
+        );
+        return;
+      }
       if (parsed && !validateFirebaseConfig(parsed)) {
         setFeedback('Configuração Firebase incompleta.');
         return;

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -14,6 +14,20 @@ let firebaseApp: FirebaseApp | null = null;
 let firestoreDb: Firestore | null = null;
 let cachedConfig: FirebaseConfig | null = null;
 
+export function looksLikeServiceAccountConfig(config: unknown): boolean {
+  if (!config || typeof config !== 'object') {
+    return false;
+  }
+  const candidate = config as Record<string, unknown>;
+  if (candidate.type === 'service_account') {
+    return true;
+  }
+  const hasPrivateKey = typeof candidate.private_key === 'string';
+  const hasClientEmail = typeof candidate.client_email === 'string';
+  const hasUniverseDomain = typeof candidate.universe_domain === 'string';
+  return Boolean(hasPrivateKey && hasClientEmail && hasUniverseDomain);
+}
+
 function configsAreEqual(a: FirebaseConfig, b: FirebaseConfig): boolean {
   return (
     a.apiKey === b.apiKey &&


### PR DESCRIPTION
## Summary
- add detection for Firebase service account credentials to prevent invalid saves
- show a clear guidance message in settings when a service account JSON is provided

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e37d801cd08327a1e621dcee518a66