### PR TITLE
Persist uploaded documents to Firestore and enforce OpenAI requirement

### DIFF
--- a/src/data/models.ts
+++ b/src/data/models.ts
@@ -1,3 +1,5 @@
+import type { FirebaseConfig } from '../services/firebase';
+
 export type AccountType = 'corrente' | 'poupanca' | 'cartao' | 'outro';
 
 export interface Account {
@@ -60,6 +62,6 @@ export interface AppSettings {
   openAIApiKey?: string;
   openAIBaseUrl?: string;
   openAIModel?: string;
-  firebaseConfig?: Record<string, string>;
+  firebaseConfig?: FirebaseConfig;
   autoDetectFixedExpenses: boolean;
 }

--- a/src/hooks/useFirestoreSync.ts
+++ b/src/hooks/useFirestoreSync.ts
@@ -24,6 +24,11 @@ export function useFirestoreSync() {
   useEffect(() => {
     const config = settings.firebaseConfig;
     if (!config) {
+      setAccounts([]);
+      setExpenses([]);
+      setTransfers([]);
+      setDocuments([]);
+      setTimeline([]);
       return () => {
         // nothing to cleanup
       };

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -31,7 +31,9 @@ function SettingsPage() {
     event.preventDefault();
     try {
       const normalizedConfig = firebaseConfig.trim();
-      const parsed = normalizedConfig ? JSON.parse(normalizedConfig) : undefined;
+      const parsed = normalizedConfig
+        ? (JSON.parse(normalizedConfig) as Record<string, unknown>)
+        : undefined;
       if (parsed && looksLikeServiceAccountConfig(parsed)) {
         setFeedback(
           'O JSON fornecido parece ser uma credencial de Service Account. Obtenha a configuração Web do Firebase (apiKey, authDomain, projectId, …) na consola do Firebase.'
@@ -42,9 +44,12 @@ function SettingsPage() {
         setFeedback('Configuração Firebase incompleta.');
         return;
       }
+      let firebaseSettings: typeof settings.firebaseConfig;
       if (parsed && validateFirebaseConfig(parsed)) {
-        await initializeFirebase(parsed);
+        firebaseSettings = parsed;
+        await initializeFirebase(firebaseSettings);
       } else {
+        firebaseSettings = undefined;
         await resetFirebase();
       }
       const normalizedBaseUrl = openAIBaseUrl.trim();
@@ -56,13 +61,13 @@ function SettingsPage() {
           normalizedBaseUrl && normalizedBaseUrl !== DEFAULT_OPENAI_BASE_URL ? normalizedBaseUrl : undefined,
         openAIModel: normalizedModel && normalizedModel !== DEFAULT_OPENAI_MODEL ? normalizedModel : undefined,
         autoDetectFixedExpenses: autoDetect,
-        firebaseConfig: parsed
+        firebaseConfig: firebaseSettings
       });
       setOpenAIBaseUrl(normalizedBaseUrl || DEFAULT_OPENAI_BASE_URL);
       setOpenAIModel(normalizedModel || DEFAULT_OPENAI_MODEL);
-      setFirebaseConfig(parsed ? JSON.stringify(parsed, null, 2) : '');
+      setFirebaseConfig(firebaseSettings ? JSON.stringify(firebaseSettings, null, 2) : '');
       setFeedback(
-        parsed
+        firebaseSettings
           ? 'Definições guardadas e ligação ao Firebase estabelecida.'
           : 'Definições guardadas. Configuração Firebase removida.'
       );

--- a/src/pages/UploadPage.tsx
+++ b/src/pages/UploadPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { CalendarDays, Euro, FileText, Loader2, UploadCloud } from 'lucide-react';
+import { CalendarDays, Euro, FileText, Loader2, Trash2, UploadCloud } from 'lucide-react';
 import { useAppState } from '../state/AppStateContext';
 import type { DocumentMetadata } from '../data/models';
 import { extractPdfMetadata } from '../services/pdfParser';
+import { persistDocumentMetadata, removeDocumentMetadata } from '../services/documents';
+import { validateFirebaseConfig } from '../services/firebase';
 
 interface UploadFeedback {
   type: 'success' | 'error' | 'info';
@@ -19,8 +21,10 @@ const feedbackStyles: Record<UploadFeedback['type'], string> = {
 function UploadPage() {
   const documents = useAppState((state) => state.documents);
   const addDocument = useAppState((state) => state.addDocument);
+  const removeDocument = useAppState((state) => state.removeDocument);
   const settings = useAppState((state) => state.settings);
   const [isUploading, setIsUploading] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const [feedback, setFeedback] = useState<UploadFeedback | null>(null);
 
   async function handleUpload(event: React.ChangeEvent<HTMLInputElement>) {
@@ -29,15 +33,32 @@ function UploadPage() {
 
     if (file.type !== 'application/pdf') {
       setFeedback({ type: 'error', message: 'Por favor escolha um ficheiro PDF.' });
+      event.target.value = '';
+      return;
+    }
+
+    if (!settings.openAIApiKey) {
+      setFeedback({
+        type: 'error',
+        message: 'Configure a chave da OpenAI nas definições antes de carregar PDFs.'
+      });
+      event.target.value = '';
+      return;
+    }
+
+    if (!settings.firebaseConfig || !validateFirebaseConfig(settings.firebaseConfig)) {
+      setFeedback({
+        type: 'error',
+        message: 'Configure o Firebase nas definições antes de carregar PDFs.'
+      });
+      event.target.value = '';
       return;
     }
 
     setIsUploading(true);
     setFeedback({
       type: 'info',
-      message: settings.openAIApiKey
-        ? 'A extrair informação via OpenAI…'
-        : 'A extrair informação localmente no browser (adicione a chave OpenAI nas definições para OCR avançado).'
+      message: 'A extrair informação via OpenAI…'
     });
 
     try {
@@ -64,17 +85,44 @@ function UploadPage() {
         extractedAt: new Date().toISOString()
       };
 
+      await persistDocumentMetadata(metadata, settings.firebaseConfig);
       addDocument(metadata);
-      setFeedback({ type: 'success', message: 'Documento processado e adicionado à lista.' });
+      setFeedback({ type: 'success', message: 'Documento processado e guardado no Firebase.' });
     } catch (error) {
       console.error(error);
       setFeedback({
         type: 'error',
-        message: 'Não foi possível extrair dados do PDF. Tente novamente.'
+        message:
+          error instanceof Error ? error.message : 'Não foi possível extrair dados do PDF. Tente novamente.'
       });
     } finally {
       setIsUploading(false);
       event.target.value = '';
+    }
+  }
+
+  async function handleDelete(documentId: string) {
+    if (!settings.firebaseConfig || !validateFirebaseConfig(settings.firebaseConfig)) {
+      setFeedback({
+        type: 'error',
+        message: 'Configure o Firebase nas definições antes de remover documentos.'
+      });
+      return;
+    }
+
+    setDeletingId(documentId);
+    try {
+      await removeDocumentMetadata(documentId, settings.firebaseConfig);
+      removeDocument(documentId);
+      setFeedback({ type: 'success', message: 'Documento removido.' });
+    } catch (error) {
+      console.error(error);
+      setFeedback({
+        type: 'error',
+        message: error instanceof Error ? error.message : 'Não foi possível remover o documento.'
+      });
+    } finally {
+      setDeletingId(null);
     }
   }
 
@@ -150,7 +198,7 @@ function UploadPage() {
                     {new Date(doc.uploadDate).toLocaleString('pt-PT')} · {doc.sourceType}
                   </small>
                 </div>
-                <div className="flex flex-wrap gap-x-6 gap-y-2 text-sm text-slate-600">
+                <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
                   {doc.amount && (
                     <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
                       <Euro className="h-4 w-4 text-slate-400" />
@@ -163,6 +211,15 @@ function UploadPage() {
                       Vencimento: {new Date(doc.dueDate).toLocaleDateString('pt-PT')}
                     </span>
                   )}
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(doc.id)}
+                    disabled={deletingId === doc.id}
+                    className="inline-flex items-center gap-2 rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-700 transition hover:border-rose-300 hover:bg-rose-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 disabled:opacity-60"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    {deletingId === doc.id ? 'A remover…' : 'Remover'}
+                  </button>
                 </div>
               </div>
               {doc.notes && <p className="mt-3 text-sm text-slate-600">{doc.notes}</p>}

--- a/src/services/documents.ts
+++ b/src/services/documents.ts
@@ -1,0 +1,25 @@
+import type { DocumentMetadata } from '../data/models';
+import type { FirebaseConfig } from './firebase';
+import { initializeFirebase, validateFirebaseConfig } from './firebase';
+import { createDocument, deleteDocumentById } from './firestore';
+
+const DOCUMENTS_COLLECTION = 'documents';
+
+export async function persistDocumentMetadata(
+  document: DocumentMetadata,
+  config: FirebaseConfig
+): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await createDocument<DocumentMetadata>(db, DOCUMENTS_COLLECTION, document);
+}
+
+export async function removeDocumentMetadata(id: string, config: FirebaseConfig): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await deleteDocumentById(db, DOCUMENTS_COLLECTION, id);
+}

--- a/src/services/pdfParser.ts
+++ b/src/services/pdfParser.ts
@@ -5,7 +5,6 @@ import {
   type OpenAIDocumentExtraction,
   type OpenAIConnectionConfig
 } from './openai';
-import { extractMetadataLocally } from './pdfLocalExtractor';
 
 export interface PdfExtractionRequest {
   file: File;
@@ -50,12 +49,9 @@ async function extractWithOpenAI(request: PdfExtractionRequest): Promise<PdfExtr
 }
 
 export async function extractPdfMetadata(request: PdfExtractionRequest): Promise<PdfExtractionResult> {
-  if (hasValidOpenAIConfig(request.openAI)) {
-    try {
-      return await extractWithOpenAI(request);
-    } catch (error) {
-      console.error('Falha ao extrair dados com a OpenAI, a recorrer à extração local.', error);
-    }
+  if (!hasValidOpenAIConfig(request.openAI)) {
+    throw new Error('É necessário configurar a API da OpenAI para ler PDFs.');
   }
-  return await extractMetadataLocally(request.file, { accountContext: request.accountContext });
+
+  return await extractWithOpenAI(request);
 }

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -15,13 +15,6 @@ import type {
   TimelineEntry,
   Transfer
 } from '../data/models';
-import {
-  mockAccounts,
-  mockDocuments,
-  mockExpenses,
-  mockTimeline,
-  mockTransfers
-} from '../data/mockData';
 import { loadPersistedSettings, persistSettings } from './settingsPersistence';
 
 export interface AppState {
@@ -34,6 +27,9 @@ export interface AppState {
   addDocument: (doc: DocumentMetadata) => void;
   addExpense: (expense: Expense) => void;
   addTransfer: (transfer: Transfer) => void;
+  removeDocument: (documentId: string) => void;
+  removeExpense: (expenseId: string) => void;
+  removeTransfer: (transferId: string) => void;
   setAccounts: (accounts: Account[]) => void;
   setExpenses: (expenses: Expense[]) => void;
   setTransfers: (transfers: Transfer[]) => void;
@@ -57,11 +53,11 @@ function resolveInitialSettings(initialState?: Partial<AppState>): AppSettings {
 
 export const createAppStore = (initialState?: Partial<AppState>) =>
   createStore<AppState>((set) => ({
-    accounts: initialState?.accounts ?? mockAccounts,
-    expenses: initialState?.expenses ?? mockExpenses,
-    transfers: initialState?.transfers ?? mockTransfers,
-    documents: initialState?.documents ?? mockDocuments,
-    timeline: initialState?.timeline ?? mockTimeline,
+    accounts: initialState?.accounts ?? [],
+    expenses: initialState?.expenses ?? [],
+    transfers: initialState?.transfers ?? [],
+    documents: initialState?.documents ?? [],
+    timeline: initialState?.timeline ?? [],
     settings: resolveInitialSettings(initialState),
     addDocument: (doc) =>
       set((state) => ({
@@ -74,6 +70,18 @@ export const createAppStore = (initialState?: Partial<AppState>) =>
     addTransfer: (transfer) =>
       set((state) => ({
         transfers: [transfer, ...state.transfers]
+      })),
+    removeDocument: (documentId) =>
+      set((state) => ({
+        documents: state.documents.filter((doc) => doc.id !== documentId)
+      })),
+    removeExpense: (expenseId) =>
+      set((state) => ({
+        expenses: state.expenses.filter((expense) => expense.id !== expenseId)
+      })),
+    removeTransfer: (transferId) =>
+      set((state) => ({
+        transfers: state.transfers.filter((transfer) => transfer.id !== transferId)
       })),
     setAccounts: (accounts) => set(() => ({ accounts })),
     setExpenses: (expenses) => set(() => ({ expenses })),

--- a/src/state/settingsPersistence.ts
+++ b/src/state/settingsPersistence.ts
@@ -1,5 +1,6 @@
 import type { AppSettings } from '../data/models';
 import { validateFirebaseConfig } from '../services/firebase';
+import type { FirebaseConfig } from '../services/firebase';
 
 const SETTINGS_STORAGE_KEY = 'ai-budget-settings';
 
@@ -22,7 +23,7 @@ function getStorage(): StorageLike | null {
   return null;
 }
 
-function sanitiseFirebaseConfig(value: unknown): Record<string, string> | undefined {
+function sanitiseFirebaseConfig(value: unknown): FirebaseConfig | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
   }
@@ -32,7 +33,7 @@ function sanitiseFirebaseConfig(value: unknown): Record<string, string> | undefi
   if (!entries.length) {
     return undefined;
   }
-  const candidate = Object.fromEntries(entries) as Record<string, string>;
+  const candidate = Object.fromEntries(entries) as FirebaseConfig;
   if (!validateFirebaseConfig(candidate)) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- remove mock data defaults from the Zustand store and add removal helpers while clearing state when Firebase sync is disabled
- require a valid OpenAI key and Firebase config before processing uploads, persist/delete documents through the new Firestore helper, and add UI affordances to remove documents
- tighten settings persistence by reusing the FirebaseConfig type and wiring SettingsPage parsing through the shared validators

## Testing
- npm run build
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68e384d1bcb88327aff5530869df0ed3