### PR TITLE
Handle OpenAI balance endpoint restrictions

### DIFF
--- a/scripts/test-openai.ts
+++ b/scripts/test-openai.ts
@@ -11,6 +11,18 @@ interface CliOptions {
   accountContext?: string;
 }
 
+function formatBalanceAmount(amount: number, currency?: string): string {
+  const normalisedCurrency = (currency || 'USD').toUpperCase();
+  try {
+    return new Intl.NumberFormat('pt-PT', {
+      style: 'currency',
+      currency: normalisedCurrency
+    }).format(amount);
+  } catch {
+    return `${amount.toFixed(2)} ${normalisedCurrency}`;
+  }
+}
+
 function resolveEnv(): CliOptions {
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
@@ -38,6 +50,21 @@ async function runValidation(options: CliOptions) {
 
   if (result.success) {
     console.log(`✓ Ligação validada (${result.model}) em ${result.latencyMs ?? '?'} ms`);
+    if (result.balance) {
+      const available = formatBalanceAmount(result.balance.totalAvailable, result.balance.currency);
+      const granted = formatBalanceAmount(result.balance.totalGranted, result.balance.currency);
+      const used = formatBalanceAmount(result.balance.totalUsed, result.balance.currency);
+      const expires =
+        typeof result.balance.expiresAt === 'number'
+          ? new Date(result.balance.expiresAt * 1000).toLocaleDateString('pt-PT')
+          : null;
+      console.log(`  Saldo disponível: ${available} (limite ${granted}, utilizado ${used}).`);
+      if (expires) {
+        console.log(`  Créditos expiram a ${expires}.`);
+      }
+    } else if (result.balanceError) {
+      console.log(`  Nota: ${result.balanceError}`);
+    }
   } else {
     console.log('⚠︎ A API respondeu mas a validação falhou:');
     console.log(result.message);


### PR DESCRIPTION
## Summary
- load available OpenAI models from the OpenAI API and surface them as a selectable list in the settings UI with refresh and error states
- fetch the current OpenAI credit balance during connection validation and present it in both the UI and CLI helper script, now gracefully handling dashboard-only restrictions with clear messaging
- enhance the OpenAI test script to print formatted balance information when available or explain why it cannot be retrieved

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3b88f26548327b9b5eb3f5c25b4e2