### PR TITLE
Improve integration log pagination accuracy

### DIFF
--- a/src/data/models.ts
+++ b/src/data/models.ts
@@ -1,4 +1,5 @@
 import type { FirebaseConfig } from '../services/firebase';
+import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE } from '../types/integrationLogs';
 
 export type AccountType = 'corrente' | 'poupanca' | 'cartao' | 'outro';
 
@@ -64,4 +65,7 @@ export interface AppSettings {
   openAIModel?: string;
   firebaseConfig?: FirebaseConfig;
   autoDetectFixedExpenses: boolean;
+  integrationLogsPageSize: number;
 }
+
+export const DEFAULT_INTEGRATION_LOGS_PAGE_SIZE_SETTING = DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppState } from '../state/AppStateContext';
 import {
@@ -13,7 +13,6 @@ import {
   DEFAULT_OPENAI_MODEL,
   validateOpenAIConnection
 } from '../services/openai';
-import { persistAllIntegrationLogsToFirebase } from '../services/integrationLogs';
 import {
   getIntegrationLogs,
   logFirebaseEvent,
@@ -21,6 +20,62 @@ import {
   subscribeToIntegrationLogs
 } from '../services/integrationLogger';
 import type { IntegrationLogsState } from '../types/integrationLogs';
+import {
+  DEFAULT_INTEGRATION_LOGS_PAGE_SIZE,
+  MAX_INTEGRATION_LOGS
+} from '../types/integrationLogs';
+
+const MIN_INTEGRATION_LOGS_PAGE_SIZE = 1;
+
+function normaliseLogsPerPage(value?: number | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
+  }
+  const rounded = Math.floor(value);
+  if (rounded < MIN_INTEGRATION_LOGS_PAGE_SIZE) {
+    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
+  }
+  if (rounded > MAX_INTEGRATION_LOGS) {
+    return MAX_INTEGRATION_LOGS;
+  }
+  return rounded;
+}
+
+interface PaginatedLogsResult<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  rangeStart: number;
+  rangeEnd: number;
+  hasMultiplePages: boolean;
+}
+
+function paginateLogs<T>(
+  items: readonly T[],
+  requestedPageSize: number,
+  requestedPage: number
+): PaginatedLogsResult<T> {
+  const totalItems = items.length;
+  const pageSize = normaliseLogsPerPage(requestedPageSize);
+  const totalPages = totalItems === 0 ? 1 : Math.max(1, Math.ceil(totalItems / pageSize));
+  const safePage = Math.min(Math.max(Math.floor(requestedPage) || 1, 1), totalPages);
+  const startIndex = totalItems === 0 ? 0 : (safePage - 1) * pageSize;
+  const endIndex = totalItems === 0 ? 0 : Math.min(startIndex + pageSize, totalItems);
+  const pageItems = items.slice(startIndex, endIndex);
+
+  return {
+    items: pageItems,
+    page: safePage,
+    pageSize,
+    totalItems,
+    totalPages,
+    rangeStart: totalItems === 0 ? 0 : startIndex + 1,
+    rangeEnd: totalItems === 0 ? 0 : startIndex + pageItems.length,
+    hasMultiplePages: totalItems > pageSize
+  };
+}
 
 function SettingsPage() {
   const settings = useAppState((state) => state.settings);
@@ -38,11 +93,16 @@ function SettingsPage() {
   const [isTestingOpenAI, setIsTestingOpenAI] = useState(false);
   const [isTestingFirebase, setIsTestingFirebase] = useState(false);
   const [logsState, setLogsState] = useState<IntegrationLogsState>(() => getIntegrationLogs());
+  const [logsPerPage, setLogsPerPage] = useState(() =>
+    normaliseLogsPerPage(settings.integrationLogsPageSize)
+  );
+  const [openAILogsPage, setOpenAILogsPage] = useState(1);
+  const [firebaseLogsPage, setFirebaseLogsPage] = useState(1);
   const openAILogs = logsState.openai;
   const firebaseLogs = logsState.firebase;
-  const firebaseConfigFromSettings = settings.firebaseConfig;
-  const lastSyncedSignature = useRef<string | null>(null);
-  const isSyncingLogs = useRef(false);
+  const settingsFirebaseConfig = settings.firebaseConfig;
+  const lastSyncedLogsSignatureRef = useRef<string | null>(null);
+  const isSyncingLogsRef = useRef(false);
 
   useEffect(() => {
     return subscribeToIntegrationLogs((state) => {
@@ -50,36 +110,165 @@ function SettingsPage() {
     });
   }, []);
 
-  const logsSignature = useMemo(() => JSON.stringify(logsState), [logsState]);
-  const firebaseConfigSignature = useMemo(
-    () => (firebaseConfigFromSettings ? JSON.stringify(firebaseConfigFromSettings) : null),
-    [firebaseConfigFromSettings]
+  useEffect(() => {
+    setLogsPerPage(normaliseLogsPerPage(settings.integrationLogsPageSize));
+  }, [settings.integrationLogsPageSize]);
+
+  const logsPerPageOptions = useMemo(() => {
+    const baseOptions = [
+      5,
+      10,
+      15,
+      20,
+      DEFAULT_INTEGRATION_LOGS_PAGE_SIZE,
+      MAX_INTEGRATION_LOGS,
+      logsPerPage
+    ];
+    const filtered = baseOptions
+      .map((value) => normaliseLogsPerPage(value))
+      .filter((value) => value >= MIN_INTEGRATION_LOGS_PAGE_SIZE && value <= MAX_INTEGRATION_LOGS);
+    const unique = Array.from(new Set(filtered));
+    unique.sort((a, b) => a - b);
+    return unique;
+  }, [logsPerPage]);
+
+  const logsPerPageSelectId = 'integration-logs-page-size';
+
+  const sortedOpenAILogs = useMemo(() => openAILogs.slice().reverse(), [openAILogs]);
+  const sortedFirebaseLogs = useMemo(() => firebaseLogs.slice().reverse(), [firebaseLogs]);
+
+  const openAIPagination = useMemo(
+    () => paginateLogs(sortedOpenAILogs, logsPerPage, openAILogsPage),
+    [logsPerPage, openAILogsPage, sortedOpenAILogs]
+  );
+
+  const firebasePagination = useMemo(
+    () => paginateLogs(sortedFirebaseLogs, logsPerPage, firebaseLogsPage),
+    [firebaseLogsPage, logsPerPage, sortedFirebaseLogs]
   );
 
   useEffect(() => {
-    if (!firebaseConfigFromSettings || !validateFirebaseConfig(firebaseConfigFromSettings)) {
-      lastSyncedSignature.current = null;
+    if (openAILogsPage !== openAIPagination.page) {
+      setOpenAILogsPage(openAIPagination.page);
+    }
+  }, [openAILogsPage, openAIPagination.page]);
+
+  useEffect(() => {
+    if (firebaseLogsPage !== firebasePagination.page) {
+      setFirebaseLogsPage(firebasePagination.page);
+    }
+  }, [firebaseLogsPage, firebasePagination.page]);
+
+  useEffect(() => {
+    setOpenAILogsPage(1);
+    setFirebaseLogsPage(1);
+  }, [logsPerPage]);
+
+  const {
+    items: paginatedOpenAILogs,
+    totalItems: openAILogsTotal,
+    totalPages: openAILogsTotalPages,
+    page: openAILogsCurrentPage,
+    rangeStart: openAILogsRangeStart,
+    rangeEnd: openAILogsRangeEnd,
+    hasMultiplePages: shouldShowOpenAILogsPagination
+  } = openAIPagination;
+
+  const {
+    items: paginatedFirebaseLogs,
+    totalItems: firebaseLogsTotal,
+    totalPages: firebaseLogsTotalPages,
+    page: firebaseLogsCurrentPage,
+    rangeStart: firebaseLogsRangeStart,
+    rangeEnd: firebaseLogsRangeEnd,
+    hasMultiplePages: shouldShowFirebaseLogsPagination
+  } = firebasePagination;
+
+  const handleOpenAIPreviousPage = useCallback(() => {
+    setOpenAILogsPage((current) => {
+      const clampedCurrent = Math.min(
+        Math.max(current, 1),
+        openAILogsTotalPages
+      );
+      return Math.max(1, clampedCurrent - 1);
+    });
+  }, [openAILogsTotalPages]);
+
+  const handleOpenAINextPage = useCallback(() => {
+    setOpenAILogsPage((current) => {
+      const clampedCurrent = Math.min(
+        Math.max(current, 1),
+        openAILogsTotalPages
+      );
+      return Math.min(openAILogsTotalPages, clampedCurrent + 1);
+    });
+  }, [openAILogsTotalPages]);
+
+  const handleFirebasePreviousPage = useCallback(() => {
+    setFirebaseLogsPage((current) => {
+      const clampedCurrent = Math.min(
+        Math.max(current, 1),
+        firebaseLogsTotalPages
+      );
+      return Math.max(1, clampedCurrent - 1);
+    });
+  }, [firebaseLogsTotalPages]);
+
+  const handleFirebaseNextPage = useCallback(() => {
+    setFirebaseLogsPage((current) => {
+      const clampedCurrent = Math.min(
+        Math.max(current, 1),
+        firebaseLogsTotalPages
+      );
+      return Math.min(firebaseLogsTotalPages, clampedCurrent + 1);
+    });
+  }, [firebaseLogsTotalPages]);
+
+  const handleLogsPerPageChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      const parsedValue = Number(event.target.value);
+      const nextValue = normaliseLogsPerPage(
+        Number.isFinite(parsedValue) ? parsedValue : logsPerPage
+      );
+      setLogsPerPage(nextValue);
+      setOpenAILogsPage(1);
+      setFirebaseLogsPage(1);
+      updateSettings({ integrationLogsPageSize: nextValue });
+    },
+    [logsPerPage, updateSettings]
+  );
+
+  const logsSignature = useMemo(() => JSON.stringify(logsState), [logsState]);
+  const firebaseConfigSignature = useMemo(
+    () => (settingsFirebaseConfig ? JSON.stringify(settingsFirebaseConfig) : null),
+    [settingsFirebaseConfig]
+  );
+
+  useEffect(() => {
+    if (!settingsFirebaseConfig || !validateFirebaseConfig(settingsFirebaseConfig)) {
+      lastSyncedLogsSignatureRef.current = null;
       return;
     }
 
     const signature = `${firebaseConfigSignature ?? ''}|${logsSignature}`;
-    if (lastSyncedSignature.current === signature || isSyncingLogs.current) {
+    if (lastSyncedLogsSignatureRef.current === signature || isSyncingLogsRef.current) {
       return;
     }
 
-    isSyncingLogs.current = true;
+    isSyncingLogsRef.current = true;
 
     (async () => {
       try {
-        await persistAllIntegrationLogsToFirebase(firebaseConfigFromSettings, logsState);
-        lastSyncedSignature.current = signature;
+        const { persistAllIntegrationLogsToFirebase } = await import('../services/integrationLogs');
+        await persistAllIntegrationLogsToFirebase(settingsFirebaseConfig, logsState);
+        lastSyncedLogsSignatureRef.current = signature;
       } catch (error) {
         console.error('Não foi possível sincronizar logs existentes com o Firebase.', error);
       } finally {
-        isSyncingLogs.current = false;
+        isSyncingLogsRef.current = false;
       }
     })();
-  }, [firebaseConfigFromSettings, firebaseConfigSignature, logsSignature, logsState]);
+  }, [firebaseConfigSignature, logsSignature, logsState, settingsFirebaseConfig]);
 
   const formatLogTimestamp = useMemo(
     () =>
@@ -177,7 +366,8 @@ function SettingsPage() {
           normalizedBaseUrl && normalizedBaseUrl !== DEFAULT_OPENAI_BASE_URL ? normalizedBaseUrl : undefined,
         openAIModel: normalizedModel && normalizedModel !== DEFAULT_OPENAI_MODEL ? normalizedModel : undefined,
         autoDetectFixedExpenses: autoDetect,
-        firebaseConfig: firebaseSettings
+        firebaseConfig: firebaseSettings,
+        integrationLogsPageSize: logsPerPage
       });
       setOpenAIBaseUrl(normalizedBaseUrl || DEFAULT_OPENAI_BASE_URL);
       setOpenAIModel(normalizedModel || DEFAULT_OPENAI_MODEL);
@@ -440,78 +630,150 @@ function SettingsPage() {
         transition={{ delay: 0.15, duration: 0.35, ease: 'easeOut' }}
         className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
       >
-        <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="space-y-1">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Logs de ligação</p>
             <h2 className="text-lg font-semibold text-slate-900">Estado das integrações</h2>
             <p className="text-sm text-slate-500">Acompanhe o histórico recente de eventos das integrações com a OpenAI e o Firebase.</p>
           </div>
-          <button
-            type="button"
-            onClick={handleExportLogs}
-            className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
-          >
-            Exportar logs (.txt)
-          </button>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+            <label
+              htmlFor={logsPerPageSelectId}
+              className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:flex-row sm:items-center sm:gap-3"
+            >
+              <span>Resultados por página</span>
+              <select
+                id={logsPerPageSelectId}
+                value={logsPerPage}
+                onChange={handleLogsPerPageChange}
+                className="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+              >
+                {logsPerPageOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={handleExportLogs}
+              className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+            >
+              Exportar logs (.txt)
+            </button>
+          </div>
         </header>
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">OpenAI</p>
-              <span className="text-[10px] uppercase tracking-wide text-slate-400">Últimos {openAILogs.length} eventos</span>
+              <span className="text-[10px] uppercase tracking-wide text-slate-400">
+                {openAILogsTotal === 0 ? 'Sem eventos registados' : `Total de ${openAILogsTotal} eventos`}
+              </span>
             </div>
             <ul className="space-y-2 text-sm text-slate-600">
-              {openAILogs.length === 0 ? (
+              {openAILogsTotal === 0 ? (
                 <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-400 shadow-sm">
                   Sem eventos registados.
                 </li>
               ) : (
-                openAILogs
-                  .slice()
-                  .reverse()
-                  .map((entry) => (
-                    <li
-                      key={`${entry.timestamp}-${entry.message}`}
-                      className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500 shadow-sm"
-                    >
-                      <span className="font-mono text-[10px] uppercase tracking-wide text-slate-400">
-                        {formatLogTimestamp.format(entry.timestamp)}
-                      </span>
-                      <br />
-                      {entry.message}
-                    </li>
-                  ))
+                paginatedOpenAILogs.map((entry) => (
+                  <li
+                    key={`${entry.timestamp}-${entry.message}`}
+                    className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500 shadow-sm"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-slate-400">
+                      {formatLogTimestamp.format(entry.timestamp)}
+                    </span>
+                    <br />
+                    {entry.message}
+                  </li>
+                ))
               )}
             </ul>
+            {openAILogsTotal > 0 && (
+              <div className="flex flex-col gap-2 pt-1 text-[10px] uppercase tracking-wide text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                  Mostrando {openAILogsRangeStart}–{openAILogsRangeEnd} de {openAILogsTotal} (página {openAILogsCurrentPage} de {openAILogsTotalPages})
+                </span>
+                {shouldShowOpenAILogsPagination && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleOpenAIPreviousPage}
+                      disabled={openAILogsCurrentPage === 1}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 shadow-sm transition hover:border-slate-400 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleOpenAINextPage}
+                      disabled={openAILogsCurrentPage === openAILogsTotalPages}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 shadow-sm transition hover:border-slate-400 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Seguinte
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
           <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm">
             <div className="flex items-center justify-between">
               <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Firebase</p>
-              <span className="text-[10px] uppercase tracking-wide text-slate-400">Últimos {firebaseLogs.length} eventos</span>
+              <span className="text-[10px] uppercase tracking-wide text-slate-400">
+                {firebaseLogsTotal === 0 ? 'Sem eventos registados' : `Total de ${firebaseLogsTotal} eventos`}
+              </span>
             </div>
             <ul className="space-y-2 text-sm text-slate-600">
-              {firebaseLogs.length === 0 ? (
+              {firebaseLogsTotal === 0 ? (
                 <li className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-400 shadow-sm">
                   Sem eventos registados.
                 </li>
               ) : (
-                firebaseLogs
-                  .slice()
-                  .reverse()
-                  .map((entry) => (
-                    <li
-                      key={`${entry.timestamp}-${entry.message}`}
-                      className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500 shadow-sm"
-                    >
-                      <span className="font-mono text-[10px] uppercase tracking-wide text-slate-400">
-                        {formatLogTimestamp.format(entry.timestamp)}
-                      </span>
-                      <br />
-                      {entry.message}
-                    </li>
-                  ))
+                paginatedFirebaseLogs.map((entry) => (
+                  <li
+                    key={`${entry.timestamp}-${entry.message}`}
+                    className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-500 shadow-sm"
+                  >
+                    <span className="font-mono text-[10px] uppercase tracking-wide text-slate-400">
+                      {formatLogTimestamp.format(entry.timestamp)}
+                    </span>
+                    <br />
+                    {entry.message}
+                  </li>
+                ))
               )}
             </ul>
+            {firebaseLogsTotal > 0 && (
+              <div className="flex flex-col gap-2 pt-1 text-[10px] uppercase tracking-wide text-slate-400 sm:flex-row sm:items-center sm:justify-between">
+                <span>
+                  Mostrando {firebaseLogsRangeStart}–{firebaseLogsRangeEnd} de {firebaseLogsTotal} (página {firebaseLogsCurrentPage} de {firebaseLogsTotalPages})
+                </span>
+                {shouldShowFirebaseLogsPagination && (
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={handleFirebasePreviousPage}
+                      disabled={firebaseLogsCurrentPage === 1}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 shadow-sm transition hover:border-slate-400 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleFirebaseNextPage}
+                      disabled={firebaseLogsCurrentPage === firebaseLogsTotalPages}
+                      className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-500 shadow-sm transition hover:border-slate-400 hover:text-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                      Seguinte
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </motion.section>

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -15,6 +15,7 @@ import type {
   TimelineEntry,
   Transfer
 } from '../data/models';
+import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE_SETTING } from '../data/models';
 import { loadPersistedSettings, persistSettings } from './settingsPersistence';
 
 export interface AppState {
@@ -39,7 +40,8 @@ export interface AppState {
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
-  autoDetectFixedExpenses: true
+  autoDetectFixedExpenses: true,
+  integrationLogsPageSize: DEFAULT_INTEGRATION_LOGS_PAGE_SIZE_SETTING
 };
 
 function resolveInitialSettings(initialState?: Partial<AppState>): AppSettings {

--- a/src/state/settingsPersistence.ts
+++ b/src/state/settingsPersistence.ts
@@ -1,4 +1,5 @@
 import type { AppSettings } from '../data/models';
+import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, MAX_INTEGRATION_LOGS } from '../types/integrationLogs';
 import { validateFirebaseConfig } from '../services/firebase';
 import type { FirebaseConfig } from '../services/firebase';
 
@@ -60,6 +61,14 @@ function sanitiseSettings(settings: unknown): StoredSettings | null {
   if (typeof parsed.autoDetectFixedExpenses === 'boolean') {
     result.autoDetectFixedExpenses = parsed.autoDetectFixedExpenses;
   }
+  const logsPageSize = Number(parsed.integrationLogsPageSize);
+  if (
+    Number.isInteger(logsPageSize) &&
+    logsPageSize >= 1 &&
+    logsPageSize <= MAX_INTEGRATION_LOGS
+  ) {
+    result.integrationLogsPageSize = logsPageSize;
+  }
   const firebaseConfig = sanitiseFirebaseConfig(parsed.firebaseConfig);
   if (firebaseConfig) {
     result.firebaseConfig = firebaseConfig;
@@ -98,7 +107,8 @@ export function persistSettings(settings: AppSettings): void {
   }
   try {
     const payload: StoredSettings = {
-      autoDetectFixedExpenses: settings.autoDetectFixedExpenses
+      autoDetectFixedExpenses: settings.autoDetectFixedExpenses,
+      integrationLogsPageSize: settings.integrationLogsPageSize || DEFAULT_INTEGRATION_LOGS_PAGE_SIZE
     };
     if (settings.openAIApiKey) {
       payload.openAIApiKey = settings.openAIApiKey;

--- a/src/types/integrationLogs.ts
+++ b/src/types/integrationLogs.ts
@@ -11,3 +11,4 @@ export interface IntegrationLogsState {
 }
 
 export const MAX_INTEGRATION_LOGS = 20;
+export const DEFAULT_INTEGRATION_LOGS_PAGE_SIZE = 5;


### PR DESCRIPTION
## Summary
- normalise integration log page size values and add a shared pagination helper that clamps pages and ranges
- update the settings page to reuse the helper for both integration feeds and guard pagination button handlers with the clamped totals
- ensure the per-page selector includes the current value while persisting the normalised size back into settings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3ab71672083279d94b8dba9e3d252