### PR TITLE
Prevent duplicate documents and upsert store entries

### DIFF
--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -63,15 +63,15 @@ export const createAppStore = (initialState?: Partial<AppState>) =>
     settings: resolveInitialSettings(initialState),
     addDocument: (doc) =>
       set((state) => ({
-        documents: [doc, ...state.documents]
+        documents: [doc, ...state.documents.filter((existing) => existing.id !== doc.id)]
       })),
     addExpense: (expense) =>
       set((state) => ({
-        expenses: [expense, ...state.expenses]
+        expenses: [expense, ...state.expenses.filter((existing) => existing.id !== expense.id)]
       })),
     addTransfer: (transfer) =>
       set((state) => ({
-        transfers: [transfer, ...state.transfers]
+        transfers: [transfer, ...state.transfers.filter((existing) => existing.id !== transfer.id)]
       })),
     removeDocument: (documentId) =>
       set((state) => ({


### PR DESCRIPTION
## Summary
- ensure document uploads reuse the existing record when the same file name is processed again
- update local state helpers to upsert documents, expenses and transfers by id to avoid duplicates
- refresh user feedback to indicate when a document was updated instead of inserted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e30d00588327a98b7cb5a4c17c89