### PR TITLE
Add monthly needs summary to Transfers analysis

### DIFF
--- a/src/pages/TransfersPage.tsx
+++ b/src/pages/TransfersPage.tsx
@@ -1,8 +1,8 @@
-import { FormEvent, useState } from 'react';
+import { FormEvent, useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { ArrowRightLeft, CalendarDays, Euro, Plus } from 'lucide-react';
+import { AlertCircle, ArrowRightLeft, CalendarDays, Euro, Plus } from 'lucide-react';
 import { useAppState } from '../state/AppStateContext';
-import type { Transfer } from '../data/models';
+import type { DocumentMetadata, Transfer } from '../data/models';
 
 const defaultTransfer = (fromAccountId: string, toAccountId: string): Transfer => ({
   id: crypto.randomUUID(),
@@ -17,11 +17,142 @@ const defaultTransfer = (fromAccountId: string, toAccountId: string): Transfer =
 function TransfersPage() {
   const accounts = useAppState((state) => state.accounts);
   const transfers = useAppState((state) => state.transfers);
+  const documents = useAppState((state) => state.documents);
   const addTransfer = useAppState((state) => state.addTransfer);
 
   const [draft, setDraft] = useState(() =>
     defaultTransfer(accounts[0]?.id ?? '', accounts[1]?.id ?? accounts[0]?.id ?? '')
   );
+
+  type MonthlyRequirementEntry = {
+    monthKey: string;
+    monthLabel: string;
+    total: number;
+    currency: string;
+    documents: DocumentMetadata[];
+  };
+
+  type AccountMonthlyRequirement = {
+    accountId?: string;
+    accountName: string;
+    currency: string;
+    months: MonthlyRequirementEntry[];
+    total: number;
+  };
+
+  const {
+    monthlySummaries,
+    missingAmountDocs,
+    missingDateDocs,
+    missingAccountDocs
+  } = useMemo(() => {
+    const UNASSIGNED_KEY = '__unassigned__';
+    const normalizedAccounts = accounts.map((account) => ({
+      ...account,
+      normalizedName: account.name.toLowerCase().trim()
+    }));
+
+    const monthsByAccount = new Map<string, Map<string, MonthlyRequirementEntry>>();
+    const missingAmount: DocumentMetadata[] = [];
+    const missingDate: DocumentMetadata[] = [];
+    const missingAccount: DocumentMetadata[] = [];
+
+    documents.forEach((doc) => {
+      if (doc.amount == null) {
+        missingAmount.push(doc);
+        return;
+      }
+
+      if (!doc.dueDate) {
+        missingDate.push(doc);
+        return;
+      }
+
+      const dueDate = new Date(doc.dueDate);
+      if (Number.isNaN(dueDate.getTime())) {
+        missingDate.push(doc);
+        return;
+      }
+
+      const monthKey = `${dueDate.getFullYear()}-${String(dueDate.getMonth() + 1).padStart(2, '0')}`;
+      const monthLabel = dueDate.toLocaleDateString('pt-PT', { month: 'long', year: 'numeric' });
+
+      const hint = doc.accountHint?.toLowerCase().trim();
+      const matchedAccount = hint
+        ? normalizedAccounts.find(
+            (account) =>
+              account.normalizedName === hint ||
+              account.normalizedName.includes(hint) ||
+              hint.includes(account.normalizedName)
+          )
+        : undefined;
+
+      const accountKey = matchedAccount?.id ?? UNASSIGNED_KEY;
+      if (!monthsByAccount.has(accountKey)) {
+        monthsByAccount.set(accountKey, new Map());
+      }
+
+      const accountMonths = monthsByAccount.get(accountKey)!;
+      const currency = doc.currency ?? matchedAccount?.currency ?? 'EUR';
+
+      if (!accountMonths.has(monthKey)) {
+        accountMonths.set(monthKey, {
+          monthKey,
+          monthLabel,
+          total: 0,
+          currency,
+          documents: []
+        });
+      }
+
+      const monthEntry = accountMonths.get(monthKey)!;
+      monthEntry.total += doc.amount;
+      monthEntry.documents.push(doc);
+      if (!monthEntry.currency && currency) {
+        monthEntry.currency = currency;
+      }
+
+      if (!matchedAccount) {
+        missingAccount.push(doc);
+      }
+    });
+
+    const summaries: AccountMonthlyRequirement[] = Array.from(monthsByAccount.entries()).map(
+      ([accountKey, monthsMap]) => {
+        const months = Array.from(monthsMap.values()).sort((a, b) =>
+          a.monthKey.localeCompare(b.monthKey)
+        );
+
+        const account =
+          accountKey === UNASSIGNED_KEY
+            ? undefined
+            : accounts.find((item) => item.id === accountKey);
+
+        const total = months.reduce((sum, month) => sum + month.total, 0);
+
+        return {
+          accountId: account?.id,
+          accountName: account?.name ?? 'Conta não identificada',
+          currency: account?.currency ?? months[0]?.currency ?? 'EUR',
+          months,
+          total
+        } satisfies AccountMonthlyRequirement;
+      }
+    );
+
+    summaries.sort((a, b) => {
+      if (a.accountId && !b.accountId) return -1;
+      if (!a.accountId && b.accountId) return 1;
+      return a.accountName.localeCompare(b.accountName, 'pt-PT');
+    });
+
+    return {
+      monthlySummaries: summaries,
+      missingAmountDocs: missingAmount,
+      missingDateDocs: missingDate,
+      missingAccountDocs: missingAccount
+    };
+  }, [accounts, documents]);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) {
     const { name, value } = event.target;
@@ -49,6 +180,105 @@ function TransfersPage() {
           Planeie transferências entre contas e acompanhe as execuções futuras.
         </p>
       </header>
+
+      <section className="space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold text-slate-900 sm:text-xl">
+            Necessidades mensais por conta
+          </h2>
+          <p className="text-sm text-slate-500">
+            Com base nos documentos importados com valor e data de vencimento identificados.
+          </p>
+        </div>
+
+        {monthlySummaries.length === 0 ? (
+          <div className="rounded-2xl border border-dashed border-slate-300 bg-white/70 p-6 text-sm text-slate-500">
+            Ainda não existem documentos com informação suficiente para calcular as necessidades mensais.
+          </div>
+        ) : (
+          <div className="grid gap-4 lg:grid-cols-2">
+            {monthlySummaries.map((summary) => (
+              <div
+                key={summary.accountId ?? 'unassigned'}
+                className="space-y-4 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <h3 className="text-base font-semibold text-slate-900">
+                      {summary.accountName}
+                    </h3>
+                    <p className="text-xs text-slate-500">
+                      Total previsto: {summary.total.toFixed(2)} {summary.currency}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-3 py-1 text-xs font-medium ${
+                      summary.accountId
+                        ? 'bg-slate-100 text-slate-600'
+                        : 'bg-amber-100 text-amber-700'
+                    }`}
+                  >
+                    {summary.accountId
+                      ? `${summary.months.length} mês${summary.months.length === 1 ? '' : 'es'}`
+                      : 'Rever conta'}
+                  </span>
+                </div>
+                <ul className="divide-y divide-slate-100">
+                  {summary.months.map((month) => (
+                    <li
+                      key={`${summary.accountId ?? 'unassigned'}-${month.monthKey}`}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <div className="space-y-1">
+                        <span className="text-sm font-medium capitalize text-slate-900">
+                          {month.monthLabel}
+                        </span>
+                        <span className="text-xs text-slate-500">
+                          {month.documents.length} documento
+                          {month.documents.length === 1 ? '' : 's'}
+                        </span>
+                      </div>
+                      <span className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+                        <Euro className="h-4 w-4 text-slate-400" />
+                        {month.total.toFixed(2)} {month.currency}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {(missingAmountDocs.length > 0 ||
+          missingDateDocs.length > 0 ||
+          missingAccountDocs.length > 0) && (
+          <div className="flex items-start gap-3 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div className="space-y-2">
+              <p className="font-medium">Alguns documentos precisam de revisão</p>
+              <ul className="space-y-1 text-xs text-amber-700/90">
+                {missingAmountDocs.length > 0 && (
+                  <li>
+                    <strong>{missingAmountDocs.length}</strong> sem valor identificado.
+                  </li>
+                )}
+                {missingDateDocs.length > 0 && (
+                  <li>
+                    <strong>{missingDateDocs.length}</strong> sem data de vencimento válida.
+                  </li>
+                )}
+                {missingAccountDocs.length > 0 && (
+                  <li>
+                    <strong>{missingAccountDocs.length}</strong> sem conta associada — atribua a conta correta para
+                    melhorar a análise.
+                  </li>
+                )}
+              </ul>
+            </div>
+          </div>
+        )}
+      </section>
 
       <motion.form
         onSubmit={handleSubmit}


### PR DESCRIPTION
## Summary
- calculate monthly account requirements from imported documents on the Transfers page
- highlight documents missing amount, due date or account hints for review
- present monthly totals per account to plan upcoming transfers

## Testing
- npm test -- --run --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68e3e6a704fc83278dcb45b51374dff9