### PR TITLE
Prevent duplicate documents and upsert store entries

### DIFF
--- a/src/data/models.ts
+++ b/src/data/models.ts
@@ -16,6 +16,7 @@ export interface Expense {
   accountId: string;
   description: string;
   category: string;
+  documentId?: string;
   amount: number;
   currency: string;
   dueDate: string;

--- a/src/pages/UploadPage.tsx
+++ b/src/pages/UploadPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { CalendarDays, Euro, FileText, Loader2, Trash2, UploadCloud } from 'lucide-react';
+import { Building2, CalendarDays, Euro, FileText, Loader2, Trash2, UploadCloud } from 'lucide-react';
 import { useAppState } from '../state/AppStateContext';
-import type { DocumentMetadata } from '../data/models';
+import type { Account, DocumentMetadata, Expense, TimelineEntry } from '../data/models';
 import { extractPdfMetadata, isPdfFile } from '../services/pdfParser';
 import { persistDocumentMetadata, removeDocumentMetadata } from '../services/documents';
 import { validateFirebaseConfig } from '../services/firebase';
+import { persistExpense } from '../services/expenses';
+import { persistTimelineEntry } from '../services/timeline';
 
 interface UploadFeedback {
   type: 'success' | 'error' | 'info';
@@ -18,10 +20,189 @@ const feedbackStyles: Record<UploadFeedback['type'], string> = {
   info: 'rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 shadow-sm'
 };
 
+const ACCOUNT_IDENTIFIER_KEYS = ['iban', 'ibanNumber', 'accountNumber', 'number', 'identifier'] as const;
+
+function normaliseIdentifier(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]/gi, '')
+    .toLowerCase();
+}
+
+function extractAccountCandidates(account: Account): string[] {
+  const candidateValues = new Set<string>();
+  candidateValues.add(account.id);
+  candidateValues.add(account.name);
+
+  const accountRecord = account as Account & Record<string, unknown>;
+  for (const key of ACCOUNT_IDENTIFIER_KEYS) {
+    const value = accountRecord[key];
+    if (typeof value === 'string') {
+      candidateValues.add(value);
+    }
+  }
+
+  const metadata = accountRecord['metadata'];
+  if (metadata && typeof metadata === 'object') {
+    for (const key of ACCOUNT_IDENTIFIER_KEYS) {
+      const value = (metadata as Record<string, unknown>)[key];
+      if (typeof value === 'string') {
+        candidateValues.add(value);
+      }
+    }
+  }
+
+  return Array.from(candidateValues).filter((candidate) => candidate.trim().length > 0);
+}
+
+function resolveAccountId(
+  accountHint: string | undefined,
+  accounts: Account[],
+  existingAccountId?: string
+): string | undefined {
+  if (existingAccountId) {
+    return existingAccountId;
+  }
+  if (accounts.length === 0) {
+    return undefined;
+  }
+  if (!accountHint || accountHint.trim().length === 0) {
+    return accounts.length === 1 ? accounts[0].id : undefined;
+  }
+
+  const normalisedHint = normaliseIdentifier(accountHint);
+  if (!normalisedHint) {
+    return accounts.length === 1 ? accounts[0].id : undefined;
+  }
+
+  for (const account of accounts) {
+    const candidates = extractAccountCandidates(account)
+      .map(normaliseIdentifier)
+      .filter((candidate) => candidate.length > 0);
+
+    const hasMatch = candidates.some((candidate) => {
+      if (candidate === normalisedHint) {
+        return true;
+      }
+      if (candidate.length < 4) {
+        return false;
+      }
+      return candidate.includes(normalisedHint) || normalisedHint.includes(candidate);
+    });
+
+    if (hasMatch) {
+      return account.id;
+    }
+  }
+
+  return accounts.length === 1 ? accounts[0].id : undefined;
+}
+
+function findAccountByHint(accountHint: string | undefined, accounts: Account[]): Account | undefined {
+  if (!accountHint || accountHint.trim().length === 0) {
+    return undefined;
+  }
+  const normalisedHint = normaliseIdentifier(accountHint);
+  if (!normalisedHint) {
+    return undefined;
+  }
+
+  return accounts.find((account) => {
+    const candidates = extractAccountCandidates(account)
+      .map(normaliseIdentifier)
+      .filter((candidate) => candidate.length > 0);
+
+    return candidates.some((candidate) => {
+      if (candidate === normalisedHint) {
+        return true;
+      }
+      if (candidate.length < 4) {
+        return false;
+      }
+      return candidate.includes(normalisedHint) || normalisedHint.includes(candidate);
+    });
+  });
+}
+
+function humaniseDocumentName(originalName: string): string {
+  const withoutExtension = originalName.replace(/\.[^/.]+$/, '');
+  const withSpaces = withoutExtension.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (withSpaces.length === 0) {
+    return 'Documento';
+  }
+  return withSpaces
+    .split(' ')
+    .map((segment) => (segment.length > 0 ? segment[0].toUpperCase() + segment.slice(1) : segment))
+    .join(' ');
+}
+
+function deriveExpenseFromDocument(
+  metadata: DocumentMetadata,
+  accounts: Account[],
+  existingExpense?: Expense
+): Expense | null {
+  const resolvedAccountId = resolveAccountId(metadata.accountHint, accounts, existingExpense?.accountId);
+  const resolvedAmount = metadata.amount ?? existingExpense?.amount;
+  const resolvedDueDate = metadata.dueDate ?? existingExpense?.dueDate ?? metadata.uploadDate;
+
+  if (!existingExpense && (resolvedAmount === undefined || !metadata.dueDate)) {
+    return null;
+  }
+  if (!resolvedAccountId) {
+    return existingExpense ?? null;
+  }
+  if (resolvedAmount === undefined) {
+    return existingExpense ?? null;
+  }
+
+  const expense: Expense = {
+    id: existingExpense?.id ?? `doc-exp-${metadata.id}`,
+    documentId: metadata.id,
+    accountId: resolvedAccountId,
+    description: existingExpense?.description ?? humaniseDocumentName(metadata.originalName),
+    category: existingExpense?.category ?? 'Outros',
+    amount: resolvedAmount,
+    currency: metadata.currency ?? existingExpense?.currency ?? 'EUR',
+    dueDate: resolvedDueDate,
+    recurrence: existingExpense?.recurrence,
+    fixed: existingExpense?.fixed ?? true,
+    status: existingExpense?.status ?? 'planeado'
+  };
+
+  return expense;
+}
+
+function deriveTimelineEntryFromExpense(
+  expense: Expense,
+  existingEntry?: TimelineEntry
+): TimelineEntry | null {
+  if (!expense.dueDate) {
+    return existingEntry ?? null;
+  }
+
+  const entry: TimelineEntry = {
+    id: existingEntry?.id ?? `doc-timeline-${expense.documentId ?? expense.id}`,
+    date: expense.dueDate,
+    type: 'despesa',
+    description: existingEntry?.description ?? expense.description,
+    amount: expense.amount,
+    currency: expense.currency,
+    linkedExpenseId: expense.id
+  };
+
+  return entry;
+}
+
 function UploadPage() {
   const documents = useAppState((state) => state.documents);
+  const expenses = useAppState((state) => state.expenses);
+  const timelineEntries = useAppState((state) => state.timeline);
+  const accounts = useAppState((state) => state.accounts);
   const addDocument = useAppState((state) => state.addDocument);
+  const addExpense = useAppState((state) => state.addExpense);
   const removeDocument = useAppState((state) => state.removeDocument);
+  const addTimelineEntry = useAppState((state) => state.addTimelineEntry);
   const settings = useAppState((state) => state.settings);
   const [isUploading, setIsUploading] = useState(false);
   const [deletingId, setDeletingId] = useState<string | null>(null);
@@ -62,6 +243,11 @@ function UploadPage() {
     });
 
     try {
+      const normalizedName = file.name.toLocaleLowerCase();
+      const existingDocument = documents.find(
+        (document) => document.originalName.toLocaleLowerCase() === normalizedName
+      );
+      const nowIsoString = new Date().toISOString();
       const extraction = await extractPdfMetadata({
         file,
         openAI: settings.openAIApiKey
@@ -73,9 +259,9 @@ function UploadPage() {
           : undefined
       });
       const metadata: DocumentMetadata = {
-        id: crypto.randomUUID(),
+        id: existingDocument?.id ?? crypto.randomUUID(),
         originalName: file.name,
-        uploadDate: new Date().toISOString(),
+        uploadDate: nowIsoString,
         sourceType: extraction.sourceType ?? 'fatura',
         amount: extraction.amount,
         currency: extraction.currency,
@@ -87,7 +273,33 @@ function UploadPage() {
 
       await persistDocumentMetadata(metadata, settings.firebaseConfig);
       addDocument(metadata);
-      setFeedback({ type: 'success', message: 'Documento processado e guardado no Firebase.' });
+
+      const existingExpense = expenses.find((expense) => expense.documentId === metadata.id);
+      const derivedExpense = deriveExpenseFromDocument(metadata, accounts, existingExpense);
+
+      if (derivedExpense) {
+        await persistExpense(derivedExpense, settings.firebaseConfig);
+        addExpense(derivedExpense);
+
+        const existingTimelineEntry = timelineEntries.find(
+          (entry) => entry.linkedExpenseId === derivedExpense.id
+        );
+        const derivedTimelineEntry = deriveTimelineEntryFromExpense(
+          derivedExpense,
+          existingTimelineEntry
+        );
+
+        if (derivedTimelineEntry) {
+          await persistTimelineEntry(derivedTimelineEntry, settings.firebaseConfig);
+          addTimelineEntry(derivedTimelineEntry);
+        }
+      }
+      setFeedback({
+        type: 'success',
+        message: existingDocument
+          ? 'Documento atualizado e guardado no Firebase.'
+          : 'Documento processado e guardado no Firebase.'
+      });
     } catch (error) {
       console.error(error);
       setFeedback({
@@ -180,51 +392,60 @@ function UploadPage() {
           </span>
         </div>
         <div className="grid gap-3">
-          {documents.map((doc) => (
-            <motion.article
-              key={doc.id}
-              layout
-              initial={{ opacity: 0, y: 8 }}
-              animate={{ opacity: 1, y: 0 }}
-              className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="flex items-center gap-2 text-sm font-medium text-slate-900">
-                    <FileText className="h-4 w-4 text-slate-400" />
-                    {doc.originalName}
-                  </p>
-                  <small className="text-xs uppercase tracking-wide text-slate-400">
-                    {new Date(doc.uploadDate).toLocaleString('pt-PT')} · {doc.sourceType}
-                  </small>
+          {documents.map((doc) => {
+            const matchedAccount = findAccountByHint(doc.accountHint, accounts);
+            return (
+              <motion.article
+                key={doc.id}
+                layout
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md"
+              >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <p className="flex items-center gap-2 text-sm font-medium text-slate-900">
+                      <FileText className="h-4 w-4 text-slate-400" />
+                      {doc.originalName}
+                    </p>
+                    <small className="text-xs uppercase tracking-wide text-slate-400">
+                      {new Date(doc.uploadDate).toLocaleString('pt-PT')} · {doc.sourceType}
+                    </small>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
+                    {doc.accountHint && (
+                      <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                        <Building2 className="h-4 w-4 text-slate-400" />
+                        {matchedAccount ? matchedAccount.name : doc.accountHint}
+                      </span>
+                    )}
+                    {doc.amount && (
+                      <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                        <Euro className="h-4 w-4 text-slate-400" />
+                        {doc.amount.toFixed(2)} {doc.currency}
+                      </span>
+                    )}
+                    {doc.dueDate && (
+                      <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
+                        <CalendarDays className="h-4 w-4 text-slate-400" />
+                        Vencimento: {new Date(doc.dueDate).toLocaleDateString('pt-PT')}
+                      </span>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(doc.id)}
+                      disabled={deletingId === doc.id}
+                      className="inline-flex items-center gap-2 rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-700 transition hover:border-rose-300 hover:bg-rose-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 disabled:opacity-60"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      {deletingId === doc.id ? 'A remover…' : 'Remover'}
+                    </button>
+                  </div>
                 </div>
-                <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600">
-                  {doc.amount && (
-                    <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                      <Euro className="h-4 w-4 text-slate-400" />
-                      {doc.amount.toFixed(2)} {doc.currency}
-                    </span>
-                  )}
-                  {doc.dueDate && (
-                    <span className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1">
-                      <CalendarDays className="h-4 w-4 text-slate-400" />
-                      Vencimento: {new Date(doc.dueDate).toLocaleDateString('pt-PT')}
-                    </span>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(doc.id)}
-                    disabled={deletingId === doc.id}
-                    className="inline-flex items-center gap-2 rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-700 transition hover:border-rose-300 hover:bg-rose-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-400 disabled:opacity-60"
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    {deletingId === doc.id ? 'A remover…' : 'Remover'}
-                  </button>
-                </div>
-              </div>
-              {doc.notes && <p className="mt-3 text-sm text-slate-600">{doc.notes}</p>}
-            </motion.article>
-          ))}
+                {doc.notes && <p className="mt-3 text-sm text-slate-600">{doc.notes}</p>}
+              </motion.article>
+            );
+          })}
           {documents.length === 0 && (
             <div className="rounded-2xl border border-dashed border-slate-300 bg-white/70 p-6 text-sm text-slate-500">
               Ainda não carregou documentos.

--- a/src/services/expenses.ts
+++ b/src/services/expenses.ts
@@ -1,0 +1,22 @@
+import type { Expense } from '../data/models';
+import type { FirebaseConfig } from './firebase';
+import { initializeFirebase, validateFirebaseConfig } from './firebase';
+import { createDocument, deleteDocumentById } from './firestore';
+
+const EXPENSES_COLLECTION = 'expenses';
+
+export async function persistExpense(expense: Expense, config: FirebaseConfig): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await createDocument<Expense>(db, EXPENSES_COLLECTION, expense);
+}
+
+export async function removeExpenseMetadata(id: string, config: FirebaseConfig): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await deleteDocumentById(db, EXPENSES_COLLECTION, id);
+}

--- a/src/services/timeline.ts
+++ b/src/services/timeline.ts
@@ -1,0 +1,22 @@
+import type { TimelineEntry } from '../data/models';
+import type { FirebaseConfig } from './firebase';
+import { initializeFirebase, validateFirebaseConfig } from './firebase';
+import { createDocument, deleteDocumentById } from './firestore';
+
+const TIMELINE_COLLECTION = 'timeline';
+
+export async function persistTimelineEntry(entry: TimelineEntry, config: FirebaseConfig): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await createDocument<TimelineEntry>(db, TIMELINE_COLLECTION, entry);
+}
+
+export async function removeTimelineEntryById(id: string, config: FirebaseConfig): Promise<void> {
+  if (!validateFirebaseConfig(config)) {
+    throw new Error('Configuração Firebase inválida.');
+  }
+  const { db } = await initializeFirebase(config);
+  await deleteDocumentById(db, TIMELINE_COLLECTION, id);
+}

--- a/src/state/AppStateContext.tsx
+++ b/src/state/AppStateContext.tsx
@@ -28,9 +28,11 @@ export interface AppState {
   addDocument: (doc: DocumentMetadata) => void;
   addExpense: (expense: Expense) => void;
   addTransfer: (transfer: Transfer) => void;
+  addTimelineEntry: (entry: TimelineEntry) => void;
   removeDocument: (documentId: string) => void;
   removeExpense: (expenseId: string) => void;
   removeTransfer: (transferId: string) => void;
+  removeTimelineEntry: (entryId: string) => void;
   setAccounts: (accounts: Account[]) => void;
   setExpenses: (expenses: Expense[]) => void;
   setTransfers: (transfers: Transfer[]) => void;
@@ -63,15 +65,19 @@ export const createAppStore = (initialState?: Partial<AppState>) =>
     settings: resolveInitialSettings(initialState),
     addDocument: (doc) =>
       set((state) => ({
-        documents: [doc, ...state.documents]
+        documents: [doc, ...state.documents.filter((existing) => existing.id !== doc.id)]
       })),
     addExpense: (expense) =>
       set((state) => ({
-        expenses: [expense, ...state.expenses]
+        expenses: [expense, ...state.expenses.filter((existing) => existing.id !== expense.id)]
       })),
     addTransfer: (transfer) =>
       set((state) => ({
-        transfers: [transfer, ...state.transfers]
+        transfers: [transfer, ...state.transfers.filter((existing) => existing.id !== transfer.id)]
+      })),
+    addTimelineEntry: (entry) =>
+      set((state) => ({
+        timeline: [entry, ...state.timeline.filter((existing) => existing.id !== entry.id)]
       })),
     removeDocument: (documentId) =>
       set((state) => ({
@@ -84,6 +90,10 @@ export const createAppStore = (initialState?: Partial<AppState>) =>
     removeTransfer: (transferId) =>
       set((state) => ({
         transfers: state.transfers.filter((transfer) => transfer.id !== transferId)
+      })),
+    removeTimelineEntry: (entryId) =>
+      set((state) => ({
+        timeline: state.timeline.filter((entry) => entry.id !== entryId)
       })),
     setAccounts: (accounts) => set(() => ({ accounts })),
     setExpenses: (expenses) => set(() => ({ expenses })),


### PR DESCRIPTION
## Summary
- ensure document uploads reuse the existing record when the same file name is processed again
- update local state helpers to upsert documents, expenses and transfers by id to avoid duplicates
- refresh user feedback to indicate when a document was updated instead of inserted
- derive expenses and timeline entries from extracted metadata so reuploads update linked data
- persist derived expenses/timeline to Firestore and surface detected account hints in the upload history

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3e30d00588327a98b7cb5a4c17c89