### PR TITLE
Add Documentos area with paginated history and richer metadata

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
-import UploadPage from './pages/UploadPage';
+import DocumentsPage from './pages/DocumentsPage';
 import TransfersPage from './pages/TransfersPage';
 import TimelinePage from './pages/TimelinePage';
 import ExpensesPage from './pages/ExpensesPage';
@@ -15,8 +15,8 @@ function App() {
   return (
     <AppLayout>
       <Routes>
-        <Route path="/" element={<Navigate to="/upload" replace />} />
-        <Route path="/upload" element={<UploadPage />} />
+        <Route path="/" element={<Navigate to="/documents" replace />} />
+        <Route path="/documents" element={<DocumentsPage />} />
         <Route path="/transfers" element={<TransfersPage />} />
         <Route path="/timeline" element={<TimelinePage />} />
         <Route path="/expenses" element={<ExpensesPage />} />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -2,17 +2,10 @@ import { NavLink, useLocation } from 'react-router-dom';
 import type { PropsWithChildren } from 'react';
 import { motion } from 'framer-motion';
 import type { LucideIcon } from 'lucide-react';
-import {
-  CalendarDays,
-  ReceiptText,
-  RefreshCcw,
-  Settings,
-  UploadCloud,
-  Wallet2
-} from 'lucide-react';
+import { CalendarDays, Files, ReceiptText, RefreshCcw, Settings, Wallet2 } from 'lucide-react';
 
 const links: Array<{ to: string; label: string; icon: LucideIcon }> = [
-  { to: '/upload', label: 'Upload PDFs', icon: UploadCloud },
+  { to: '/documents', label: 'Documentos', icon: Files },
   { to: '/transfers', label: 'Transferências', icon: RefreshCcw },
   { to: '/timeline', label: 'Timeline', icon: CalendarDays },
   { to: '/expenses', label: 'Despesas', icon: Wallet2 },

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -67,6 +67,8 @@ export const mockDocuments: DocumentMetadata[] = [
     currency: 'EUR',
     dueDate: new Date().toISOString(),
     accountHint: 'Conta Corrente',
+    companyName: 'Energia Lisboa',
+    expenseType: 'Luz',
     extractedAt: new Date().toISOString()
   }
 ];

--- a/src/data/models.ts
+++ b/src/data/models.ts
@@ -45,6 +45,8 @@ export interface DocumentMetadata {
   currency?: string;
   dueDate?: string;
   accountHint?: string;
+  companyName?: string;
+  expenseType?: string;
   notes?: string;
   extractedAt?: string;
 }

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -79,6 +79,8 @@ export interface OpenAIDocumentExtraction {
   currency?: string;
   dueDate?: string;
   accountHint?: string;
+  companyName?: string;
+  expenseType?: string;
   notes?: string;
   rawResponse?: unknown;
 }
@@ -585,12 +587,12 @@ export async function extractPdfMetadataWithOpenAI({
               {
                 type: 'input_text',
                 text:
-                  'Analisa o PDF fornecido e devolve um JSON com os campos "sourceType", "amount", "currency", "dueDate", "accountHint" e "notes". ' +
+                  'Analisa o PDF fornecido e devolve um JSON com os campos "sourceType", "amount", "currency", "dueDate", "accountHint", "companyName", "expenseType" e "notes". ' +
                   'sourceType deve ser um de: fatura, recibo ou extracto. amount deve ser número. dueDate deve estar em ISO 8601 se existir. ' +
                   (accountContext
                     ? `A conta de contexto preferencial é "${accountContext}". Considera-a ao interpretar o documento. `
                     : '') +
-                  'Se um campo não existir, devolve null.'
+                  'Se um campo não existir, devolve null. companyName deve refletir a entidade emissora (empresa ou organização). expenseType deve indicar a categoria ou tipo da despesa (ex.: Luz, Água, Renda).'
               },
               {
                 type: 'input_file',
@@ -622,11 +624,26 @@ export async function extractPdfMetadataWithOpenAI({
                 accountHint: {
                   type: ['string', 'null']
                 },
+                companyName: {
+                  type: ['string', 'null']
+                },
+                expenseType: {
+                  type: ['string', 'null']
+                },
                 notes: {
                   type: ['string', 'null']
                 }
               },
-              required: ['sourceType', 'amount', 'currency', 'dueDate', 'accountHint', 'notes'],
+              required: [
+                'sourceType',
+                'amount',
+                'currency',
+                'dueDate',
+                'accountHint',
+                'companyName',
+                'expenseType',
+                'notes'
+              ],
               additionalProperties: false
             }
           }
@@ -644,6 +661,8 @@ export async function extractPdfMetadataWithOpenAI({
         currency: typeof parsed.currency === 'string' ? parsed.currency : undefined,
         dueDate: typeof parsed.dueDate === 'string' ? parsed.dueDate : undefined,
         accountHint: typeof parsed.accountHint === 'string' ? parsed.accountHint : undefined,
+        companyName: typeof parsed.companyName === 'string' ? parsed.companyName : undefined,
+        expenseType: typeof parsed.expenseType === 'string' ? parsed.expenseType : undefined,
         notes: typeof parsed.notes === 'string' ? parsed.notes : undefined,
         rawResponse: payload
       };

--- a/src/services/pdfParser.ts
+++ b/src/services/pdfParser.ts
@@ -70,6 +70,8 @@ async function extractWithOpenAI(request: PdfExtractionRequest): Promise<PdfExtr
     currency: extraction.currency,
     dueDate: extraction.dueDate,
     accountHint: extraction.accountHint,
+    companyName: extraction.companyName,
+    expenseType: extraction.expenseType,
     notes: extraction.notes,
     rawResponse: extraction.rawResponse
   } satisfies PdfExtractionResult;


### PR DESCRIPTION
## Summary
- create a dedicated Documentos page that handles uploads and shows a paginated document history with extracted details
- extend document metadata to include company and expense type information from OpenAI extractions and use them for derived expenses
- update navigation, routing, and mock data to point to the new area and surface the additional fields

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e3ea726b8c83279df3092ab610addd