### PR TITLE
Add IBAN-focused hint instruction for OpenAI extraction

### DIFF
--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -589,6 +589,7 @@ export async function extractPdfMetadataWithOpenAI({
                 text:
                   'Analisa o PDF fornecido e devolve um JSON com os campos "sourceType", "amount", "currency", "dueDate", "accountHint", "companyName", "expenseType" e "notes". ' +
                   'sourceType deve ser um de: fatura, recibo ou extracto. amount deve ser número. dueDate deve estar em ISO 8601 se existir. ' +
+                  'Para identificar o accountHint, procura explicitamente por campos etiquetados como "IBAN" e devolve esse valor quando estiver presente. ' +
                   (accountContext
                     ? `A conta de contexto preferencial é "${accountContext}". Considera-a ao interpretar o documento. `
                     : '') +


### PR DESCRIPTION
## Summary
- update the OpenAI extraction prompt to explicitly look for fields labelled IBAN when determining the account hint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3ee4d61188327b29f28798cfcd16e