### PR TITLE
Fix legacy settings migration for OpenAI and Firebase configuration

### DIFF
--- a/src/state/AppStateContext.test.tsx
+++ b/src/state/AppStateContext.test.tsx
@@ -46,6 +46,109 @@ describe('AppState store', () => {
     });
   });
 
+  it('migra definições antigas com chaves legacy', () => {
+    const legacyPayload = {
+      openaiApiKey: 'sk-legacy',
+      openaiBaseUrl: 'https://legacy.openai.test/v1',
+      openaiModel: 'gpt-3.5-turbo',
+      autoDetectRecurringExpenses: false,
+      logsPerPage: '15',
+      firebaseConfigJson: JSON.stringify({ apiKey: 'legacy', authDomain: 'legacy.firebaseapp.com', projectId: 'legacy-project' })
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(legacyPayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-legacy');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://legacy.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-3.5-turbo');
+    expect(result.current.settings.autoDetectFixedExpenses).toBe(false);
+    expect(result.current.settings.integrationLogsPageSize).toBe(15);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'legacy',
+      authDomain: 'legacy.firebaseapp.com',
+      projectId: 'legacy-project'
+    });
+  });
+
+  it('migra definições aninhadas em contentores legacy', () => {
+    const nestedPayload = {
+      settings: {
+        openai: {
+          apiKey: 'sk-nested',
+          baseUrl: 'https://nested.openai.test/v1',
+          modelName: 'gpt-4o-mini'
+        },
+        autoDetectRecurringExpenses: true,
+        logsPerPage: '15',
+        firebase: {
+          config: {
+            apiKey: 'nested',
+            authDomain: 'nested.firebaseapp.com',
+            projectId: 'nested-project'
+          }
+        }
+      }
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(nestedPayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-nested');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://nested.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-4o-mini');
+    expect(result.current.settings.autoDetectFixedExpenses).toBe(true);
+    expect(result.current.settings.integrationLogsPageSize).toBe(15);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'nested',
+      authDomain: 'nested.firebaseapp.com',
+      projectId: 'nested-project'
+    });
+  });
+
+  it('migra nomes alternativos de contentores e propriedades', () => {
+    const alternativePayload = {
+      configuration: {
+        openAISettings: {
+          token: 'sk-alt',
+          endpoint: 'https://alt.openai.test/v1',
+          model: 'gpt-4.1-mini'
+        },
+        firebaseOptions: JSON.stringify({
+          apiKey: 'alt',
+          authDomain: 'alt.firebaseapp.com',
+          projectId: 'alt-project'
+        }),
+        integrationLogsPageSizeSetting: 12
+      }
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(alternativePayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-alt');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://alt.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-4.1-mini');
+    expect(result.current.settings.integrationLogsPageSize).toBe(12);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'alt',
+      authDomain: 'alt.firebaseapp.com',
+      projectId: 'alt-project'
+    });
+  });
+
   it('substitui coleções através dos setters', () => {
     const store = createAppStore();
     const { result } = renderHook(() => useAppState((state) => state), {

--- a/src/state/settingsPersistence.ts
+++ b/src/state/settingsPersistence.ts
@@ -1,6 +1,6 @@
 import type { AppSettings } from '../data/models';
 import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, MAX_INTEGRATION_LOGS } from '../types/integrationLogs';
-import { validateFirebaseConfig } from '../services/firebase';
+import { looksLikeServiceAccountConfig, validateFirebaseConfig } from '../services/firebase';
 import type { FirebaseConfig } from '../services/firebase';
 
 const SETTINGS_STORAGE_KEY = 'ai-budget-settings';
@@ -24,11 +24,124 @@ function getStorage(): StorageLike | null {
   return null;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normaliseKey(key: string): string {
+  return key.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const GENERAL_CONTAINER_KEYS = ['settings', 'configuration', 'config', 'preferences', 'state', 'payload', 'data', 'options'] as const;
+
+function collectGeneralSources(base: Record<string, unknown>): Record<string, unknown>[] {
+  const result: Record<string, unknown>[] = [];
+  const queue: Record<string, unknown>[] = [base];
+  const visited = new Set<Record<string, unknown>>();
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    result.push(current);
+
+    for (const [key, value] of Object.entries(current)) {
+      const nested = asRecord(value);
+      if (!nested) {
+        continue;
+      }
+      if (GENERAL_CONTAINER_KEYS.some((candidate) => normaliseKey(candidate) === normaliseKey(key))) {
+        queue.push(nested);
+      }
+    }
+  }
+
+  return result;
+}
+
+function collectContainerRecords(
+  base: Record<string, unknown>,
+  containerKeys: readonly string[]
+): Record<string, unknown>[] {
+  const matches: Record<string, unknown>[] = [];
+  const seen = new Set<Record<string, unknown>>();
+  const sources = collectGeneralSources(base);
+
+  for (const source of sources) {
+    for (const [key, value] of Object.entries(source)) {
+      const candidate = asRecord(value);
+      if (!candidate) {
+        continue;
+      }
+      if (containerKeys.some((container) => normaliseKey(container) === normaliseKey(key))) {
+        if (!seen.has(candidate)) {
+          seen.add(candidate);
+          matches.push(candidate);
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value.trim());
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    console.warn('JSON de configuração Firebase inválido detectado ao migrar definições antigas.', error);
+    return null;
+  }
+}
+
+const FIREBASE_NESTED_KEYS = ['config', 'configuration', 'settings', 'options', 'value'] as const;
+
+function toFirebaseConfigCandidate(value: unknown): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = parseJsonObject(trimmed);
+    if (!parsed) {
+      return null;
+    }
+    return toFirebaseConfigCandidate(parsed) ?? parsed;
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (looksLikeServiceAccountConfig(record)) {
+      return null;
+    }
+    for (const key of FIREBASE_NESTED_KEYS) {
+      const nested = toFirebaseConfigCandidate(record[key]);
+      if (nested) {
+        return nested;
+      }
+    }
+    return record;
+  }
+  return null;
+}
+
 function sanitiseFirebaseConfig(value: unknown): FirebaseConfig | undefined {
-  if (!value || typeof value !== 'object') {
+  const candidateObject = toFirebaseConfigCandidate(value);
+  if (!candidateObject) {
     return undefined;
   }
-  const entries = Object.entries(value as Record<string, unknown>)
+  const entries = Object.entries(candidateObject)
     .filter(([, v]) => typeof v === 'string')
     .map(([key, v]) => [key, v as string]);
   if (!entries.length) {
@@ -41,27 +154,138 @@ function sanitiseFirebaseConfig(value: unknown): FirebaseConfig | undefined {
   return candidate;
 }
 
+const OPENAI_API_KEY_CANDIDATES = ['openAIApiKey', 'openaiApiKey', 'openAiApiKey', 'openAIKey', 'openaiKey'] as const;
+const OPENAI_BASE_URL_CANDIDATES = ['openAIBaseUrl', 'openaiBaseUrl', 'openAIBaseURL', 'openaiBaseURL'] as const;
+const OPENAI_MODEL_CANDIDATES = ['openAIModel', 'openaiModel', 'openAIModelName', 'openaiModelName'] as const;
+const FIREBASE_CONFIG_CANDIDATES = ['firebaseConfig', 'firebaseConfigJson', 'firebaseConfigJSON', 'firebase', 'firebaseSettings', 'firebaseOptions'] as const;
+const OPENAI_CONTAINER_KEYS = ['openAI', 'openai', 'openAi', 'openAISettings', 'openaiSettings'] as const;
+const FIREBASE_CONTAINER_KEYS = ['firebase', 'firebaseConfig', 'firebaseSettings', 'firebaseOptions'] as const;
+const OPENAI_API_KEY_NESTED_CANDIDATES = ['apiKey', 'key', 'token', 'secret'] as const;
+const OPENAI_BASE_URL_NESTED_CANDIDATES = ['baseUrl', 'baseURL', 'url', 'endpoint'] as const;
+const OPENAI_MODEL_NESTED_CANDIDATES = ['model', 'modelName', 'chatModel'] as const;
+const LOGS_PAGE_SIZE_CANDIDATES = ['integrationLogsPageSize', 'logsPerPage', 'integrationLogsPageSizeSetting'] as const;
+
+function pickStringFromSource(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+  predicate: (value: string) => boolean = () => true
+): string | undefined {
+  if (!keys.length) {
+    return undefined;
+  }
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const [rawKey, rawValue] of Object.entries(source)) {
+    if (typeof rawValue !== 'string') {
+      continue;
+    }
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (normalisedKeys.has(normaliseKey(rawKey)) && predicate(trimmed)) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function pickStringFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[],
+  predicate: (value: string) => boolean = () => true
+): string | undefined {
+  for (const source of sources) {
+    const value = pickStringFromSource(source, keys, predicate);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickBooleanFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[]
+): boolean | undefined {
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const source of sources) {
+    for (const [rawKey, rawValue] of Object.entries(source)) {
+      if (typeof rawValue === 'boolean' && normalisedKeys.has(normaliseKey(rawKey))) {
+        return rawValue;
+      }
+    }
+  }
+  return undefined;
+}
+
+function pickNumericFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[]
+): number | undefined {
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const source of sources) {
+    for (const [rawKey, rawValue] of Object.entries(source)) {
+      if (!normalisedKeys.has(normaliseKey(rawKey))) {
+        continue;
+      }
+      if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+        return rawValue;
+      }
+      if (typeof rawValue === 'string') {
+        const parsed = Number(rawValue.trim());
+        if (Number.isInteger(parsed)) {
+          return parsed;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 function sanitiseSettings(settings: unknown): StoredSettings | null {
   if (!settings || typeof settings !== 'object') {
     return null;
   }
 
   const parsed = settings as Record<string, unknown>;
+  const generalSources = collectGeneralSources(parsed);
+  const openAISources = [
+    ...collectContainerRecords(parsed, OPENAI_CONTAINER_KEYS),
+    ...collectContainerRecords(parsed, ['openAIConfig', 'openaiConfig', 'openAIOptions', 'openaiOptions'])
+  ];
+  const firebaseSources = collectContainerRecords(parsed, FIREBASE_CONTAINER_KEYS);
   const result: StoredSettings = {};
 
-  if (typeof parsed.openAIApiKey === 'string') {
-    result.openAIApiKey = parsed.openAIApiKey;
+  const openAIApiKey =
+    pickStringFromSources(generalSources, OPENAI_API_KEY_CANDIDATES, (value) => value.length > 0) ??
+    pickStringFromSources(openAISources, OPENAI_API_KEY_NESTED_CANDIDATES, (value) => value.length > 0);
+  if (openAIApiKey) {
+    result.openAIApiKey = openAIApiKey;
   }
-  if (typeof parsed.openAIBaseUrl === 'string') {
-    result.openAIBaseUrl = parsed.openAIBaseUrl;
+
+  const openAIBaseUrl =
+    pickStringFromSources(generalSources, OPENAI_BASE_URL_CANDIDATES) ??
+    pickStringFromSources(openAISources, OPENAI_BASE_URL_NESTED_CANDIDATES);
+  if (openAIBaseUrl) {
+    result.openAIBaseUrl = openAIBaseUrl;
   }
-  if (typeof parsed.openAIModel === 'string') {
-    result.openAIModel = parsed.openAIModel;
+
+  const openAIModel =
+    pickStringFromSources(generalSources, OPENAI_MODEL_CANDIDATES) ??
+    pickStringFromSources(openAISources, OPENAI_MODEL_NESTED_CANDIDATES);
+  if (openAIModel) {
+    result.openAIModel = openAIModel;
   }
-  if (typeof parsed.autoDetectFixedExpenses === 'boolean') {
-    result.autoDetectFixedExpenses = parsed.autoDetectFixedExpenses;
+
+  const autoDetect = pickBooleanFromSources(generalSources, [
+    'autoDetectFixedExpenses',
+    'autoDetectRecurringExpenses'
+  ]);
+  if (typeof autoDetect === 'boolean') {
+    result.autoDetectFixedExpenses = autoDetect;
   }
-  const logsPageSize = Number(parsed.integrationLogsPageSize);
+
+  const logsPageSize = pickNumericFromSources(generalSources, LOGS_PAGE_SIZE_CANDIDATES);
   if (
     Number.isInteger(logsPageSize) &&
     logsPageSize >= 1 &&
@@ -69,7 +293,28 @@ function sanitiseSettings(settings: unknown): StoredSettings | null {
   ) {
     result.integrationLogsPageSize = logsPageSize;
   }
-  const firebaseConfig = sanitiseFirebaseConfig(parsed.firebaseConfig);
+
+  const firebaseSourcesToInspect = [...generalSources, ...firebaseSources, ...openAISources];
+  let firebaseConfig: FirebaseConfig | undefined;
+  for (const source of firebaseSourcesToInspect) {
+    for (const key of FIREBASE_CONFIG_CANDIDATES) {
+      const candidate = sanitiseFirebaseConfig(source[key]);
+      if (candidate) {
+        firebaseConfig = candidate;
+        break;
+      }
+    }
+    if (firebaseConfig) {
+      break;
+    }
+    if (!firebaseConfig) {
+      const nestedCandidate = sanitiseFirebaseConfig(source);
+      if (nestedCandidate) {
+        firebaseConfig = nestedCandidate;
+        break;
+      }
+    }
+  }
   if (firebaseConfig) {
     result.firebaseConfig = firebaseConfig;
   }


### PR DESCRIPTION
## Summary
- update settings persistence to recognise legacy OpenAI and Firebase key names, parse JSON strings, and traverse nested containers when loading saved settings
- add regression tests covering legacy settings payloads, including nested containers and alternative property names

## Testing
- npx vitest run

------
https://chatgpt.com/codex/tasks/task_e_68e3f72344c48327ad339befc0ebfed4