### PR TITLE
Improve OpenAI endpoint normalisation and logs pagination

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_OPENAI_BASE_URL,
   DEFAULT_OPENAI_MODEL,
   listOpenAIModels,
+  normaliseOpenAIBaseUrl,
   validateOpenAIConnection
 } from '../services/openai';
 import type { OpenAIBalanceInfo, OpenAIModelSummary } from '../services/openai';
@@ -22,68 +23,20 @@ import {
   subscribeToIntegrationLogs
 } from '../services/integrationLogger';
 import type { IntegrationLogEntry, IntegrationLogSource, IntegrationLogsState } from '../types/integrationLogs';
+import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, MAX_INTEGRATION_LOGS } from '../types/integrationLogs';
 import {
-  DEFAULT_INTEGRATION_LOGS_PAGE_SIZE,
-  MAX_INTEGRATION_LOGS
-} from '../types/integrationLogs';
-
-const MIN_INTEGRATION_LOGS_PAGE_SIZE = 1;
-
-function normaliseLogsPerPage(value?: number | null): number {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
-  }
-  const rounded = Math.floor(value);
-  if (rounded < MIN_INTEGRATION_LOGS_PAGE_SIZE) {
-    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
-  }
-  if (rounded > MAX_INTEGRATION_LOGS) {
-    return MAX_INTEGRATION_LOGS;
-  }
-  return rounded;
-}
-
-interface PaginatedLogsResult<T> {
-  items: T[];
-  page: number;
-  pageSize: number;
-  totalItems: number;
-  totalPages: number;
-  rangeStart: number;
-  rangeEnd: number;
-  hasMultiplePages: boolean;
-}
-
-function paginateLogs<T>(
-  items: readonly T[],
-  requestedPageSize: number,
-  requestedPage: number
-): PaginatedLogsResult<T> {
-  const totalItems = items.length;
-  const pageSize = normaliseLogsPerPage(requestedPageSize);
-  const totalPages = totalItems === 0 ? 1 : Math.max(1, Math.ceil(totalItems / pageSize));
-  const safePage = Math.min(Math.max(Math.floor(requestedPage) || 1, 1), totalPages);
-  const startIndex = totalItems === 0 ? 0 : (safePage - 1) * pageSize;
-  const endIndex = totalItems === 0 ? 0 : Math.min(startIndex + pageSize, totalItems);
-  const pageItems = items.slice(startIndex, endIndex);
-
-  return {
-    items: pageItems,
-    page: safePage,
-    pageSize,
-    totalItems,
-    totalPages,
-    rangeStart: totalItems === 0 ? 0 : startIndex + 1,
-    rangeEnd: totalItems === 0 ? 0 : startIndex + pageItems.length,
-    hasMultiplePages: totalItems > pageSize
-  };
-}
+  MIN_INTEGRATION_LOGS_PAGE_SIZE,
+  normaliseLogsPerPage,
+  paginateLogs
+} from './settingsLogsPagination';
 
 function SettingsPage() {
   const settings = useAppState((state) => state.settings);
   const updateSettings = useAppState((state) => state.updateSettings);
   const [apiKey, setApiKey] = useState(settings.openAIApiKey ?? '');
-  const [openAIBaseUrl, setOpenAIBaseUrl] = useState(settings.openAIBaseUrl ?? DEFAULT_OPENAI_BASE_URL);
+  const [openAIBaseUrl, setOpenAIBaseUrl] = useState(
+    normaliseOpenAIBaseUrl(settings.openAIBaseUrl)
+  );
   const [openAIModel, setOpenAIModel] = useState(settings.openAIModel ?? DEFAULT_OPENAI_MODEL);
   const [availableOpenAIModels, setAvailableOpenAIModels] = useState<OpenAIModelSummary[]>([]);
   const [isLoadingOpenAIModels, setIsLoadingOpenAIModels] = useState(false);
@@ -119,6 +72,10 @@ function SettingsPage() {
   useEffect(() => {
     setLogsPerPage(normaliseLogsPerPage(settings.integrationLogsPageSize));
   }, [settings.integrationLogsPageSize]);
+
+  useEffect(() => {
+    setOpenAIBaseUrl(normaliseOpenAIBaseUrl(settings.openAIBaseUrl));
+  }, [settings.openAIBaseUrl]);
 
   const logsPerPageOptions = useMemo(() => {
     const baseOptions = [
@@ -204,10 +161,14 @@ function SettingsPage() {
       setOpenAIModelsError(null);
 
       try {
+        const trimmedBaseUrl = openAIBaseUrl.trim();
+        const resolvedBaseUrl = trimmedBaseUrl
+          ? normaliseOpenAIBaseUrl(openAIBaseUrl)
+          : undefined;
         const models = await listOpenAIModels(
           {
             apiKey: trimmedKey,
-            baseUrl: openAIBaseUrl.trim() || undefined
+            baseUrl: resolvedBaseUrl
           },
           abortSignal
         );
@@ -460,7 +421,7 @@ function SettingsPage() {
           logFirebaseEvent('Configuração Firebase removida.');
         }
       }
-      const normalizedBaseUrl = openAIBaseUrl.trim();
+      const normalizedBaseUrl = normaliseOpenAIBaseUrl(openAIBaseUrl);
       const normalizedModel = openAIModel.trim();
 
       updateSettings({
@@ -472,7 +433,7 @@ function SettingsPage() {
         firebaseConfig: firebaseSettings,
         integrationLogsPageSize: logsPerPage
       });
-      setOpenAIBaseUrl(normalizedBaseUrl || DEFAULT_OPENAI_BASE_URL);
+      setOpenAIBaseUrl(normalizedBaseUrl);
       setOpenAIModel(normalizedModel || DEFAULT_OPENAI_MODEL);
       setFirebaseConfig(firebaseSettings ? JSON.stringify(firebaseSettings, null, 2) : '');
       setFeedback(
@@ -506,11 +467,15 @@ function SettingsPage() {
     setOpenAIBalanceError(null);
     logOpenAIEvent('A validar ligação à OpenAI…');
     try {
+      const trimmedBaseUrl = openAIBaseUrl.trim();
+      const resolvedBaseUrl = trimmedBaseUrl
+        ? normaliseOpenAIBaseUrl(openAIBaseUrl)
+        : undefined;
       const result = await validateOpenAIConnection(
         {
           apiKey,
-          baseUrl: openAIBaseUrl,
-          model: openAIModel
+          baseUrl: resolvedBaseUrl,
+          model: openAIModel.trim() || DEFAULT_OPENAI_MODEL
         },
         undefined
       );
@@ -631,6 +596,228 @@ function SettingsPage() {
         transition={{ delay: 0.1, duration: 0.35, ease: 'easeOut' }}
         className="space-y-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
       >
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">OpenAI</p>
+            <label className="block space-y-2 text-sm text-slate-600">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Chave API OpenAI</span>
+              <input
+                type="password"
+                placeholder="sk-..."
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-slate-900 focus:ring-slate-900/10"
+              />
+            </label>
+            <label className="block space-y-2 text-sm text-slate-600">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Endpoint (opcional)</span>
+              <input
+                type="url"
+                placeholder={DEFAULT_OPENAI_BASE_URL}
+                value={openAIBaseUrl}
+                onChange={(event) => setOpenAIBaseUrl(event.target.value)}
+                className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-slate-900 focus:ring-slate-900/10"
+              />
+            </label>
+            <label className="block space-y-2 text-sm text-slate-600">
+              <span className="text-xs uppercase tracking-wide text-slate-400">Modelo</span>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <select
+                  value={openAIModel}
+                  onChange={(event) => setOpenAIModel(event.target.value)}
+                  disabled={isLoadingOpenAIModels || (!hasOpenAIApiKey && availableOpenAIModels.length === 0)}
+                  className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-slate-900 focus:ring-slate-900/10 disabled:cursor-not-allowed disabled:bg-slate-100"
+                >
+                  {openAIModelOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={handleRefreshOpenAIModels}
+                  disabled={!hasOpenAIApiKey || isLoadingOpenAIModels}
+                  className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+                >
+                  {isLoadingOpenAIModels ? 'A carregar…' : 'Atualizar'}
+                </button>
+              </div>
+              {!hasOpenAIApiKey && (
+                <p className="text-xs text-slate-400">
+                  Insira a chave da OpenAI para carregar modelos disponíveis automaticamente.
+                </p>
+              )}
+              {openAIModelsError && <p className="text-xs text-amber-600">{openAIModelsError}</p>}
+            </label>
+            <button
+              type="button"
+              onClick={handleTestOpenAI}
+              disabled={isTestingOpenAI}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 md:w-auto"
+            >
+              {isTestingOpenAI ? 'A validar…' : 'Testar ligação OpenAI'}
+            </button>
+            <AnimatePresence>
+              {openAITestFeedback && (
+                <motion.p
+                  key={openAITestFeedback}
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6 }}
+                  transition={{ duration: 0.25 }}
+                  className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-600 shadow-sm"
+                >
+                  {openAITestFeedback}
+                </motion.p>
+              )}
+            </AnimatePresence>
+            <AnimatePresence>
+              {formattedOpenAIBalance && (
+                <motion.div
+                  key={`openai-balance-${formattedOpenAIBalance.available}-${formattedOpenAIBalance.used}`}
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6 }}
+                  transition={{ duration: 0.25 }}
+                  className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-600 shadow-sm"
+                >
+                  <p>
+                    Saldo disponível: <span className="font-semibold text-slate-700">{formattedOpenAIBalance.available}</span>
+                  </p>
+                  <p className="mt-1 text-[10px] uppercase tracking-wide text-slate-400">
+                    Limite: {formattedOpenAIBalance.granted} • Utilizado: {formattedOpenAIBalance.used}
+                  </p>
+                  {formattedOpenAIBalance.expiry && (
+                    <p className="mt-1 text-[10px] uppercase tracking-wide text-slate-400">
+                      Expira em {formattedOpenAIBalance.expiry}
+                    </p>
+                  )}
+                </motion.div>
+              )}
+            </AnimatePresence>
+            <AnimatePresence>
+              {openAIBalanceError && (
+                <motion.p
+                  key={openAIBalanceError}
+                  initial={{ opacity: 0, y: -6 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -6 }}
+                  transition={{ duration: 0.25 }}
+                  className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-xs text-amber-700 shadow-sm"
+                >
+                  {openAIBalanceError}
+                </motion.p>
+              )}
+            </AnimatePresence>
+          </div>
+          <div className="space-y-4 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Preferências</p>
+            <label className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-600 shadow-sm">
+              <input
+                type="checkbox"
+                checked={autoDetect}
+                onChange={(event) => setAutoDetect(event.target.checked)}
+                className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900/30"
+              />
+              Detectar automaticamente despesas fixas
+            </label>
+          </div>
+        </div>
+        <label className="block space-y-2 text-sm text-slate-600">
+          <span className="text-xs uppercase tracking-wide text-slate-400">Configuração Firebase (JSON)</span>
+          <textarea
+            rows={6}
+            value={firebaseConfig}
+            onChange={(event) => setFirebaseConfig(event.target.value)}
+            className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm placeholder:text-slate-400 focus:border-slate-900 focus:ring-slate-900/10"
+          />
+        </label>
+        <div className="space-y-3">
+          <button
+            type="button"
+            onClick={handleTestFirebase}
+            disabled={isTestingFirebase}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-2xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 sm:w-auto"
+          >
+            {isTestingFirebase ? 'A validar…' : 'Testar ligação Firebase'}
+          </button>
+          <AnimatePresence>
+            {firebaseTestFeedback && (
+              <motion.p
+                key={firebaseTestFeedback}
+                initial={{ opacity: 0, y: -6 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={{ duration: 0.25 }}
+                className="rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs text-slate-600 shadow-sm"
+              >
+                {firebaseTestFeedback}
+              </motion.p>
+            )}
+          </AnimatePresence>
+        </div>
+        <button
+          type="submit"
+          className="inline-flex w-full items-center justify-center gap-2 rounded-2xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900 sm:w-auto sm:px-6"
+        >
+          Guardar
+        </button>
+        <AnimatePresence>
+          {feedback && (
+            <motion.p
+              key={feedback}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.25 }}
+              className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-600 shadow-sm"
+            >
+              {feedback}
+            </motion.p>
+          )}
+        </AnimatePresence>
+      </motion.form>
+      <motion.section
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.15, duration: 0.35, ease: 'easeOut' }}
+        className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm"
+      >
+        <header className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Logs de ligação</p>
+            <h2 className="text-lg font-semibold text-slate-900">Estado das integrações</h2>
+            <p className="text-sm text-slate-500">Acompanhe o histórico recente de eventos das integrações com a OpenAI e o Firebase.</p>
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+            <label
+              htmlFor={logsPerPageSelectId}
+              className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:flex-row sm:items-center sm:gap-3"
+            >
+              <span>Resultados por página</span>
+              <select
+                id={logsPerPageSelectId}
+                value={logsPerPage}
+                onChange={handleLogsPerPageChange}
+                className="rounded-2xl border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+              >
+                {logsPerPageOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              type="button"
+              onClick={handleExportLogs}
+              className="inline-flex items-center justify-center rounded-2xl border border-slate-300 bg-white px-4 py-2 text-xs font-medium uppercase tracking-wide text-slate-600 shadow-sm transition hover:border-slate-400 hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+            >
+              Exportar logs (.txt)
+            </button>
+          </div>
+        </header>
         <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50/70 p-4 shadow-sm">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
@@ -701,7 +888,7 @@ function SettingsPage() {
             </div>
           )}
         </div>
-      </motion.form>
+      </motion.section>
     </motion.section>
   );
 }

--- a/src/pages/settingsLogsPagination.test.ts
+++ b/src/pages/settingsLogsPagination.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MIN_INTEGRATION_LOGS_PAGE_SIZE,
+  normaliseLogsPerPage,
+  paginateLogs
+} from './settingsLogsPagination';
+import {
+  DEFAULT_INTEGRATION_LOGS_PAGE_SIZE,
+  MAX_INTEGRATION_LOGS
+} from '../types/integrationLogs';
+
+describe('settingsLogsPagination', () => {
+  describe('normaliseLogsPerPage', () => {
+    it('devolve a predefinição quando o valor é inválido', () => {
+      expect(normaliseLogsPerPage(undefined)).toBe(DEFAULT_INTEGRATION_LOGS_PAGE_SIZE);
+      expect(normaliseLogsPerPage(null)).toBe(DEFAULT_INTEGRATION_LOGS_PAGE_SIZE);
+      expect(normaliseLogsPerPage(Number.NaN)).toBe(DEFAULT_INTEGRATION_LOGS_PAGE_SIZE);
+    });
+
+    it('arredonda e respeita limites mínimo e máximo', () => {
+      expect(normaliseLogsPerPage(1.8)).toBe(1);
+      expect(normaliseLogsPerPage(0)).toBe(DEFAULT_INTEGRATION_LOGS_PAGE_SIZE);
+      expect(normaliseLogsPerPage(-10)).toBe(DEFAULT_INTEGRATION_LOGS_PAGE_SIZE);
+      expect(normaliseLogsPerPage(1000)).toBe(MAX_INTEGRATION_LOGS);
+    });
+  });
+
+  describe('paginateLogs', () => {
+    const buildItems = (total: number) => Array.from({ length: total }, (_, index) => index + 1);
+
+    it('devolve estrutura vazia quando não existem elementos', () => {
+      const result = paginateLogs([], DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, 2);
+      expect(result.items).toEqual([]);
+      expect(result.page).toBe(1);
+      expect(result.totalItems).toBe(0);
+      expect(result.totalPages).toBe(1);
+      expect(result.hasMultiplePages).toBe(false);
+    });
+
+    it('limita o número de elementos por página e calcula intervalos correctamente', () => {
+      const result = paginateLogs(buildItems(12), DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, 1);
+      expect(result.items).toEqual([1, 2, 3, 4, 5]);
+      expect(result.rangeStart).toBe(1);
+      expect(result.rangeEnd).toBe(5);
+      expect(result.totalPages).toBe(3);
+      expect(result.hasMultiplePages).toBe(true);
+    });
+
+    it('traz a última página válida quando o pedido excede o total disponível', () => {
+      const result = paginateLogs(buildItems(9), 4, 5);
+      expect(result.page).toBe(3);
+      expect(result.items).toEqual([9]);
+      expect(result.rangeStart).toBe(9);
+      expect(result.rangeEnd).toBe(9);
+    });
+
+    it('assegura que o número de página mínimo é 1', () => {
+      const result = paginateLogs(buildItems(3), DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, -10);
+      expect(result.page).toBe(1);
+    });
+
+    it('tolera actualizações de tamanho para valores fora dos limites', () => {
+      const result = paginateLogs(buildItems(30), MIN_INTEGRATION_LOGS_PAGE_SIZE - 10, 1);
+      expect(result.pageSize).toBeGreaterThan(0);
+      expect(result.items.length).toBe(result.pageSize);
+    });
+  });
+});

--- a/src/pages/settingsLogsPagination.ts
+++ b/src/pages/settingsLogsPagination.ts
@@ -1,0 +1,72 @@
+import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, MAX_INTEGRATION_LOGS } from '../types/integrationLogs';
+
+const MIN_INTEGRATION_LOGS_PAGE_SIZE = 1;
+
+export function normaliseLogsPerPage(value?: number | null): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
+  }
+
+  const rounded = Math.floor(value);
+  if (rounded < MIN_INTEGRATION_LOGS_PAGE_SIZE) {
+    return DEFAULT_INTEGRATION_LOGS_PAGE_SIZE;
+  }
+
+  if (rounded > MAX_INTEGRATION_LOGS) {
+    return MAX_INTEGRATION_LOGS;
+  }
+
+  return rounded;
+}
+
+export interface PaginatedLogsResult<T> {
+  items: T[];
+  page: number;
+  pageSize: number;
+  totalItems: number;
+  totalPages: number;
+  rangeStart: number;
+  rangeEnd: number;
+  hasMultiplePages: boolean;
+}
+
+export function paginateLogs<T>(
+  items: readonly T[],
+  requestedPageSize: number,
+  requestedPage: number
+): PaginatedLogsResult<T> {
+  const totalItems = items.length;
+  const pageSize = normaliseLogsPerPage(requestedPageSize);
+  const totalPages = totalItems === 0 ? 1 : Math.max(1, Math.ceil(totalItems / pageSize));
+  const safePage = Math.min(Math.max(Math.floor(requestedPage) || 1, 1), totalPages);
+
+  if (totalItems === 0) {
+    return {
+      items: [],
+      page: 1,
+      pageSize,
+      totalItems: 0,
+      totalPages: 1,
+      rangeStart: 0,
+      rangeEnd: 0,
+      hasMultiplePages: false
+    } satisfies PaginatedLogsResult<T>;
+  }
+
+  const startIndex = (safePage - 1) * pageSize;
+  const endIndex = Math.min(startIndex + pageSize, totalItems);
+  const pageItems = items.slice(startIndex, endIndex);
+
+  return {
+    items: pageItems,
+    page: safePage,
+    pageSize,
+    totalItems,
+    totalPages,
+    rangeStart: startIndex + 1,
+    rangeEnd: startIndex + pageItems.length,
+    hasMultiplePages: totalPages > 1
+  } satisfies PaginatedLogsResult<T>;
+}
+
+export { MIN_INTEGRATION_LOGS_PAGE_SIZE };

--- a/src/services/openaiBaseUrl.test.ts
+++ b/src/services/openaiBaseUrl.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_OPENAI_BASE_URL, normaliseOpenAIBaseUrl } from './openai';
+
+describe('normaliseOpenAIBaseUrl', () => {
+  it('devolve a predefinição quando o valor é vazio ou inválido', () => {
+    expect(normaliseOpenAIBaseUrl()).toBe(DEFAULT_OPENAI_BASE_URL);
+    expect(normaliseOpenAIBaseUrl('')).toBe(DEFAULT_OPENAI_BASE_URL);
+    expect(normaliseOpenAIBaseUrl('   ')).toBe(DEFAULT_OPENAI_BASE_URL);
+    expect(normaliseOpenAIBaseUrl('nota-url')).toBe(DEFAULT_OPENAI_BASE_URL);
+  });
+
+  it('garante que o protocolo é sempre https e acrescenta /v1 quando necessário', () => {
+    expect(normaliseOpenAIBaseUrl('api.openai.com/v1')).toBe('https://api.openai.com/v1');
+    expect(normaliseOpenAIBaseUrl('http://api.openai.com/v1')).toBe('https://api.openai.com/v1');
+    expect(normaliseOpenAIBaseUrl('https://api.openai.com')).toBe('https://api.openai.com/v1');
+    expect(normaliseOpenAIBaseUrl('https://api.openai.com/v1/')).toBe('https://api.openai.com/v1');
+  });
+
+  it('mantém URLs personalizadas, apenas removendo barras supérfluas', () => {
+    expect(
+      normaliseOpenAIBaseUrl('https://contoso.openai.azure.com/openai/deployments/model')
+    ).toBe('https://contoso.openai.azure.com/openai/deployments/model');
+  });
+
+  it('permite hosts locais sem forçar HTTPS', () => {
+    expect(normaliseOpenAIBaseUrl('http://localhost:8787/v1')).toBe('http://localhost:8787/v1');
+    expect(normaliseOpenAIBaseUrl('localhost:8787/v1')).toBe('https://localhost:8787/v1');
+  });
+
+  it('normaliza espaços em branco e caminhos adicionais', () => {
+    expect(normaliseOpenAIBaseUrl('  https://api.openai.com/v1/chat ')).toBe(
+      'https://api.openai.com/v1/chat'
+    );
+  });
+});

--- a/src/state/AppStateContext.test.tsx
+++ b/src/state/AppStateContext.test.tsx
@@ -46,6 +46,109 @@ describe('AppState store', () => {
     });
   });
 
+  it('migra definições antigas com chaves legacy', () => {
+    const legacyPayload = {
+      openaiApiKey: 'sk-legacy',
+      openaiBaseUrl: 'https://legacy.openai.test/v1',
+      openaiModel: 'gpt-3.5-turbo',
+      autoDetectRecurringExpenses: false,
+      logsPerPage: '15',
+      firebaseConfigJson: JSON.stringify({ apiKey: 'legacy', authDomain: 'legacy.firebaseapp.com', projectId: 'legacy-project' })
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(legacyPayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-legacy');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://legacy.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-3.5-turbo');
+    expect(result.current.settings.autoDetectFixedExpenses).toBe(false);
+    expect(result.current.settings.integrationLogsPageSize).toBe(15);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'legacy',
+      authDomain: 'legacy.firebaseapp.com',
+      projectId: 'legacy-project'
+    });
+  });
+
+  it('migra definições aninhadas em contentores legacy', () => {
+    const nestedPayload = {
+      settings: {
+        openai: {
+          apiKey: 'sk-nested',
+          baseUrl: 'https://nested.openai.test/v1',
+          modelName: 'gpt-4o-mini'
+        },
+        autoDetectRecurringExpenses: true,
+        logsPerPage: '15',
+        firebase: {
+          config: {
+            apiKey: 'nested',
+            authDomain: 'nested.firebaseapp.com',
+            projectId: 'nested-project'
+          }
+        }
+      }
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(nestedPayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-nested');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://nested.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-4o-mini');
+    expect(result.current.settings.autoDetectFixedExpenses).toBe(true);
+    expect(result.current.settings.integrationLogsPageSize).toBe(15);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'nested',
+      authDomain: 'nested.firebaseapp.com',
+      projectId: 'nested-project'
+    });
+  });
+
+  it('migra nomes alternativos de contentores e propriedades', () => {
+    const alternativePayload = {
+      configuration: {
+        openAISettings: {
+          token: 'sk-alt',
+          endpoint: 'https://alt.openai.test/v1',
+          model: 'gpt-4.1-mini'
+        },
+        firebaseOptions: JSON.stringify({
+          apiKey: 'alt',
+          authDomain: 'alt.firebaseapp.com',
+          projectId: 'alt-project'
+        }),
+        integrationLogsPageSizeSetting: 12
+      }
+    };
+
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(alternativePayload));
+
+    const store = createAppStore();
+    const { result } = renderHook(() => useAppState((state) => state), {
+      wrapper: ({ children }) => <AppStateProvider store={store}>{children}</AppStateProvider>
+    });
+
+    expect(result.current.settings.openAIApiKey).toBe('sk-alt');
+    expect(result.current.settings.openAIBaseUrl).toBe('https://alt.openai.test/v1');
+    expect(result.current.settings.openAIModel).toBe('gpt-4.1-mini');
+    expect(result.current.settings.integrationLogsPageSize).toBe(12);
+    expect(result.current.settings.firebaseConfig).toEqual({
+      apiKey: 'alt',
+      authDomain: 'alt.firebaseapp.com',
+      projectId: 'alt-project'
+    });
+  });
+
   it('substitui coleções através dos setters', () => {
     const store = createAppStore();
     const { result } = renderHook(() => useAppState((state) => state), {

--- a/src/state/settingsPersistence.ts
+++ b/src/state/settingsPersistence.ts
@@ -1,6 +1,6 @@
 import type { AppSettings } from '../data/models';
 import { DEFAULT_INTEGRATION_LOGS_PAGE_SIZE, MAX_INTEGRATION_LOGS } from '../types/integrationLogs';
-import { validateFirebaseConfig } from '../services/firebase';
+import { looksLikeServiceAccountConfig, validateFirebaseConfig } from '../services/firebase';
 import type { FirebaseConfig } from '../services/firebase';
 
 const SETTINGS_STORAGE_KEY = 'ai-budget-settings';
@@ -24,11 +24,124 @@ function getStorage(): StorageLike | null {
   return null;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
+}
+
+function normaliseKey(key: string): string {
+  return key.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+const GENERAL_CONTAINER_KEYS = ['settings', 'configuration', 'config', 'preferences', 'state', 'payload', 'data', 'options'] as const;
+
+function collectGeneralSources(base: Record<string, unknown>): Record<string, unknown>[] {
+  const result: Record<string, unknown>[] = [];
+  const queue: Record<string, unknown>[] = [base];
+  const visited = new Set<Record<string, unknown>>();
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) {
+      continue;
+    }
+    visited.add(current);
+    result.push(current);
+
+    for (const [key, value] of Object.entries(current)) {
+      const nested = asRecord(value);
+      if (!nested) {
+        continue;
+      }
+      if (GENERAL_CONTAINER_KEYS.some((candidate) => normaliseKey(candidate) === normaliseKey(key))) {
+        queue.push(nested);
+      }
+    }
+  }
+
+  return result;
+}
+
+function collectContainerRecords(
+  base: Record<string, unknown>,
+  containerKeys: readonly string[]
+): Record<string, unknown>[] {
+  const matches: Record<string, unknown>[] = [];
+  const seen = new Set<Record<string, unknown>>();
+  const sources = collectGeneralSources(base);
+
+  for (const source of sources) {
+    for (const [key, value] of Object.entries(source)) {
+      const candidate = asRecord(value);
+      if (!candidate) {
+        continue;
+      }
+      if (containerKeys.some((container) => normaliseKey(container) === normaliseKey(key))) {
+        if (!seen.has(candidate)) {
+          seen.add(candidate);
+          matches.push(candidate);
+        }
+      }
+    }
+  }
+
+  return matches;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value.trim());
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch (error) {
+    console.warn('JSON de configuração Firebase inválido detectado ao migrar definições antigas.', error);
+    return null;
+  }
+}
+
+const FIREBASE_NESTED_KEYS = ['config', 'configuration', 'settings', 'options', 'value'] as const;
+
+function toFirebaseConfigCandidate(value: unknown): Record<string, unknown> | null {
+  if (!value) {
+    return null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = parseJsonObject(trimmed);
+    if (!parsed) {
+      return null;
+    }
+    return toFirebaseConfigCandidate(parsed) ?? parsed;
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    if (looksLikeServiceAccountConfig(record)) {
+      return null;
+    }
+    for (const key of FIREBASE_NESTED_KEYS) {
+      const nested = toFirebaseConfigCandidate(record[key]);
+      if (nested) {
+        return nested;
+      }
+    }
+    return record;
+  }
+  return null;
+}
+
 function sanitiseFirebaseConfig(value: unknown): FirebaseConfig | undefined {
-  if (!value || typeof value !== 'object') {
+  const candidateObject = toFirebaseConfigCandidate(value);
+  if (!candidateObject) {
     return undefined;
   }
-  const entries = Object.entries(value as Record<string, unknown>)
+  const entries = Object.entries(candidateObject)
     .filter(([, v]) => typeof v === 'string')
     .map(([key, v]) => [key, v as string]);
   if (!entries.length) {
@@ -41,35 +154,168 @@ function sanitiseFirebaseConfig(value: unknown): FirebaseConfig | undefined {
   return candidate;
 }
 
+const OPENAI_API_KEY_CANDIDATES = ['openAIApiKey', 'openaiApiKey', 'openAiApiKey', 'openAIKey', 'openaiKey'] as const;
+const OPENAI_BASE_URL_CANDIDATES = ['openAIBaseUrl', 'openaiBaseUrl', 'openAIBaseURL', 'openaiBaseURL'] as const;
+const OPENAI_MODEL_CANDIDATES = ['openAIModel', 'openaiModel', 'openAIModelName', 'openaiModelName'] as const;
+const FIREBASE_CONFIG_CANDIDATES = ['firebaseConfig', 'firebaseConfigJson', 'firebaseConfigJSON', 'firebase', 'firebaseSettings', 'firebaseOptions'] as const;
+const OPENAI_CONTAINER_KEYS = ['openAI', 'openai', 'openAi', 'openAISettings', 'openaiSettings'] as const;
+const FIREBASE_CONTAINER_KEYS = ['firebase', 'firebaseConfig', 'firebaseSettings', 'firebaseOptions'] as const;
+const OPENAI_API_KEY_NESTED_CANDIDATES = ['apiKey', 'key', 'token', 'secret'] as const;
+const OPENAI_BASE_URL_NESTED_CANDIDATES = ['baseUrl', 'baseURL', 'url', 'endpoint'] as const;
+const OPENAI_MODEL_NESTED_CANDIDATES = ['model', 'modelName', 'chatModel'] as const;
+const LOGS_PAGE_SIZE_CANDIDATES = ['integrationLogsPageSize', 'logsPerPage', 'integrationLogsPageSizeSetting'] as const;
+
+function pickStringFromSource(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+  predicate: (value: string) => boolean = () => true
+): string | undefined {
+  if (!keys.length) {
+    return undefined;
+  }
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const [rawKey, rawValue] of Object.entries(source)) {
+    if (typeof rawValue !== 'string') {
+      continue;
+    }
+    const trimmed = rawValue.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (normalisedKeys.has(normaliseKey(rawKey)) && predicate(trimmed)) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function pickStringFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[],
+  predicate: (value: string) => boolean = () => true
+): string | undefined {
+  for (const source of sources) {
+    const value = pickStringFromSource(source, keys, predicate);
+    if (value) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function pickBooleanFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[]
+): boolean | undefined {
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const source of sources) {
+    for (const [rawKey, rawValue] of Object.entries(source)) {
+      if (typeof rawValue === 'boolean' && normalisedKeys.has(normaliseKey(rawKey))) {
+        return rawValue;
+      }
+    }
+  }
+  return undefined;
+}
+
+function pickNumericFromSources(
+  sources: readonly Record<string, unknown>[],
+  keys: readonly string[]
+): number | undefined {
+  const normalisedKeys = new Set(keys.map((key) => normaliseKey(key)));
+  for (const source of sources) {
+    for (const [rawKey, rawValue] of Object.entries(source)) {
+      if (!normalisedKeys.has(normaliseKey(rawKey))) {
+        continue;
+      }
+      if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+        return rawValue;
+      }
+      if (typeof rawValue === 'string') {
+        const parsed = Number(rawValue.trim());
+        if (Number.isInteger(parsed)) {
+          return parsed;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
 function sanitiseSettings(settings: unknown): StoredSettings | null {
   if (!settings || typeof settings !== 'object') {
     return null;
   }
 
   const parsed = settings as Record<string, unknown>;
+  const generalSources = collectGeneralSources(parsed);
+  const openAISources = [
+    ...collectContainerRecords(parsed, OPENAI_CONTAINER_KEYS),
+    ...collectContainerRecords(parsed, ['openAIConfig', 'openaiConfig', 'openAIOptions', 'openaiOptions'])
+  ];
+  const firebaseSources = collectContainerRecords(parsed, FIREBASE_CONTAINER_KEYS);
   const result: StoredSettings = {};
 
-  if (typeof parsed.openAIApiKey === 'string') {
-    result.openAIApiKey = parsed.openAIApiKey;
+  const openAIApiKey =
+    pickStringFromSources(generalSources, OPENAI_API_KEY_CANDIDATES, (value) => value.length > 0) ??
+    pickStringFromSources(openAISources, OPENAI_API_KEY_NESTED_CANDIDATES, (value) => value.length > 0);
+  if (openAIApiKey) {
+    result.openAIApiKey = openAIApiKey;
   }
-  if (typeof parsed.openAIBaseUrl === 'string') {
-    result.openAIBaseUrl = parsed.openAIBaseUrl;
+
+  const openAIBaseUrl =
+    pickStringFromSources(generalSources, OPENAI_BASE_URL_CANDIDATES) ??
+    pickStringFromSources(openAISources, OPENAI_BASE_URL_NESTED_CANDIDATES);
+  if (openAIBaseUrl) {
+    result.openAIBaseUrl = openAIBaseUrl;
   }
-  if (typeof parsed.openAIModel === 'string') {
-    result.openAIModel = parsed.openAIModel;
+
+  const openAIModel =
+    pickStringFromSources(generalSources, OPENAI_MODEL_CANDIDATES) ??
+    pickStringFromSources(openAISources, OPENAI_MODEL_NESTED_CANDIDATES);
+  if (openAIModel) {
+    result.openAIModel = openAIModel;
   }
-  if (typeof parsed.autoDetectFixedExpenses === 'boolean') {
-    result.autoDetectFixedExpenses = parsed.autoDetectFixedExpenses;
+
+  const autoDetect = pickBooleanFromSources(generalSources, [
+    'autoDetectFixedExpenses',
+    'autoDetectRecurringExpenses'
+  ]);
+  if (typeof autoDetect === 'boolean') {
+    result.autoDetectFixedExpenses = autoDetect;
   }
-  const logsPageSize = Number(parsed.integrationLogsPageSize);
+
+  const logsPageSize = pickNumericFromSources(generalSources, LOGS_PAGE_SIZE_CANDIDATES);
   if (
+    typeof logsPageSize === 'number' &&
     Number.isInteger(logsPageSize) &&
     logsPageSize >= 1 &&
     logsPageSize <= MAX_INTEGRATION_LOGS
   ) {
     result.integrationLogsPageSize = logsPageSize;
   }
-  const firebaseConfig = sanitiseFirebaseConfig(parsed.firebaseConfig);
+
+  const firebaseSourcesToInspect = [...generalSources, ...firebaseSources, ...openAISources];
+  let firebaseConfig: FirebaseConfig | undefined;
+  for (const source of firebaseSourcesToInspect) {
+    for (const key of FIREBASE_CONFIG_CANDIDATES) {
+      const candidate = sanitiseFirebaseConfig(source[key]);
+      if (candidate) {
+        firebaseConfig = candidate;
+        break;
+      }
+    }
+    if (firebaseConfig) {
+      break;
+    }
+    if (!firebaseConfig) {
+      const nestedCandidate = sanitiseFirebaseConfig(source);
+      if (nestedCandidate) {
+        firebaseConfig = nestedCandidate;
+        break;
+      }
+    }
+  }
   if (firebaseConfig) {
     result.firebaseConfig = firebaseConfig;
   }


### PR DESCRIPTION
## Summary
- normalise the saved OpenAI endpoint by enforcing https, defaulting to /v1, and surfacing clearer network error messages when uploads fail
- refactor settings log pagination helpers so page sizing, ranges, and navigation stay consistent with the configured size
- add regression tests that cover pagination edge cases and the OpenAI base URL sanitisation logic

## Testing
- npm test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f72344c48327ad339befc0ebfed4