### PR TITLE
Limit initial fixed expense creation window to six months

### DIFF
--- a/src/pages/ExpensesPage.helpers.test.ts
+++ b/src/pages/ExpensesPage.helpers.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { generateMonthlyOccurrences } from './ExpensesPage';
+
+function isoDate(value: string): Date {
+  return new Date(value);
+}
+
+describe('generateMonthlyOccurrences', () => {
+  it('limits the number of occurrences when a cap is provided', () => {
+    const start = isoDate('2024-01-15T00:00:00.000Z');
+    const end = isoDate('2025-01-15T00:00:00.000Z');
+
+    const occurrences = generateMonthlyOccurrences(start, end, { maxOccurrences: 6 });
+
+    expect(occurrences).toHaveLength(6);
+    expect(occurrences.at(0)?.toISOString()).toBe('2024-01-15T00:00:00.000Z');
+    expect(occurrences.at(-1)?.toISOString()).toBe('2024-06-15T00:00:00.000Z');
+  });
+
+  it('stops at the provided end date when it happens first', () => {
+    const start = isoDate('2024-01-15T00:00:00.000Z');
+    const end = isoDate('2024-04-15T00:00:00.000Z');
+
+    const occurrences = generateMonthlyOccurrences(start, end, { maxOccurrences: 6 });
+
+    expect(occurrences).toHaveLength(4);
+    expect(occurrences.at(-1)?.toISOString()).toBe('2024-04-15T00:00:00.000Z');
+  });
+
+  it('returns an empty array when the end date is before the start date', () => {
+    const start = isoDate('2024-01-15T00:00:00.000Z');
+    const end = isoDate('2023-12-15T00:00:00.000Z');
+
+    const occurrences = generateMonthlyOccurrences(start, end, { maxOccurrences: 6 });
+
+    expect(occurrences).toEqual([]);
+  });
+});

--- a/src/pages/ExpensesPage.tsx
+++ b/src/pages/ExpensesPage.tsx
@@ -45,6 +45,8 @@ const CHART_PERIOD_OPTIONS: { value: ChartPeriod; label: string }[] = [
   { value: 'total', label: 'Total' }
 ];
 
+const INITIAL_FIXED_EXPENSE_OCCURRENCES_LIMIT = 6;
+
 const CHART_PERIOD_SUMMARY: Record<ChartPeriod, string> = {
   mensal: 'no mês actual',
   anual: 'no ano em curso',
@@ -129,16 +131,21 @@ function toIsoDate(value: string): string | null {
   return parsed ? parsed.toISOString() : null;
 }
 
-function generateMonthlyOccurrences(start: Date, end: Date): Date[] {
+export function generateMonthlyOccurrences(
+  start: Date,
+  end: Date,
+  options?: { maxOccurrences?: number }
+): Date[] {
   const occurrences: Date[] = [];
   if (end < start) {
     return occurrences;
   }
 
+  const maxOccurrences = options?.maxOccurrences ?? Number.POSITIVE_INFINITY;
   const startDay = start.getUTCDate();
   let current = new Date(start);
 
-  while (current.getTime() <= end.getTime()) {
+  while (current.getTime() <= end.getTime() && occurrences.length < maxOccurrences) {
     occurrences.push(new Date(current));
     const baseYear = current.getUTCFullYear();
     const baseMonth = current.getUTCMonth();
@@ -432,7 +439,9 @@ function ExpensesPage() {
     const shouldGenerateSeries = !editingId && requiresWindow && endDate;
 
     if (shouldGenerateSeries && endDate) {
-      const occurrences = generateMonthlyOccurrences(startDate, endDate);
+      const occurrences = generateMonthlyOccurrences(startDate, endDate, {
+        maxOccurrences: INITIAL_FIXED_EXPENSE_OCCURRENCES_LIMIT
+      });
       if (occurrences.length === 0) {
         setFormError('Não existem ocorrências dentro do intervalo indicado.');
         return;


### PR DESCRIPTION
## Summary
- cap the initial creation of new fixed recurring expenses to six monthly occurrences
- expose an optional limit when generating monthly occurrences
- add unit coverage for the occurrence generator to assert the cap behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69023abd6c688327baf64362080b0269