### PR TITLE
Rename app references to Gestão de Orçamento

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Gestor de Despesas — Regras e Requisitos
+# Gestão de Orçamento — Regras e Requisitos
 
 ## Resumo
 Quero construir uma PWA WEB app para gerir as minhas despesas e transferências entre as minhas contas.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gestor de Despesas PWA
+# Gestão de Orçamento PWA
 
 Aplicação web (PWA) para gestão de despesas pessoais. O projecto está configurado com [Vite](https://vitejs.dev/),
 React e TypeScript, incluindo mock data, estado global via Zustand e uma estrutura inicial para as principais áreas da app:

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Gestor de Despesas</title>
+    <title>Gestão de Orçamento</title>
   </head>
   <body>
     <div id="initial-loader" class="initial-loader" aria-hidden="true">

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -1,6 +1,6 @@
 # n8n Workflows
 
-Este directório contém workflows n8n relacionados com a automação da aplicação Gestor de Despesas. Cada ficheiro JSON pode ser importado directamente no n8n.
+Este directório contém workflows n8n relacionados com a automação da aplicação Gestão de Orçamento. Cada ficheiro JSON pode ser importado directamente no n8n.
 
 ## Scripts disponíveis
 

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,11 +1,11 @@
 {
-  "name": "Gestor de Despesas",
-  "short_name": "Despesas",
+  "name": "Gestão de Orçamento",
+  "short_name": "Orçamento",
   "start_url": ".",
   "display": "standalone",
   "background_color": "#f8fafc",
   "theme_color": "#0f172a",
-  "description": "Gestão prática de despesas pessoais e transferências.",
+  "description": "Gestão prática de orçamento pessoal e transferências.",
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -90,8 +90,8 @@ export function AppLayout({ children }: PropsWithChildren) {
             <ReceiptText className="h-5 w-5" />
           </span>
           <div>
-            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Gestão de despesas</p>
-            <span className="text-xl font-semibold">Gestor de Despesas</span>
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">Gestão de orçamento</p>
+            <span className="text-xl font-semibold">Gestão de Orçamento</span>
           </div>
         </div>
         <nav className="flex-1 space-y-6">
@@ -114,7 +114,7 @@ export function AppLayout({ children }: PropsWithChildren) {
             <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-slate-900 text-white">
               <ReceiptText className="h-5 w-5" />
             </span>
-            <span>Gestor de Despesas</span>
+            <span>Gestão de Orçamento</span>
           </div>
           <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs text-slate-500">
             PWA

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,9 +10,9 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'icons/icon-192.png', 'icons/icon-512.png', 'icons/wallet.svg', 'icons/wallet-maskable.svg'],
       manifest: {
-        name: 'Gestor de Despesas',
-        short_name: 'Despesas',
-        description: 'Gestão prática de despesas pessoais e transferências.',
+        name: 'Gestão de Orçamento',
+        short_name: 'Orçamento',
+        description: 'Gestão prática de orçamento pessoal e transferências.',
         theme_color: '#0f172a',
         background_color: '#f8fafc',
         display: 'standalone',


### PR DESCRIPTION
## Summary
- rename the app branding to Gestão de Orçamento across documentation
- update PWA metadata and manifest values to reflect the new name
- refresh layout labels so the interface displays the new branding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69024528a0ec83279268ae2bca62aa90