### PR TITLE
Mobile-friendly UI + 3D scenes for simple-expenses

### DIFF
--- a/simple-expenses/README.md
+++ b/simple-expenses/README.md
@@ -1,9 +1,12 @@
 # Simple Expenses
 
-App web simples para gerir despesas em várias contas / cartões. 100% no browser
-(localStorage), sem backend, sem login.
+App web simples para registar despesas em várias contas / cartões — **só
+despesas, sem gestão de saldos**. 100% no browser (localStorage), sem backend,
+sem login. Com cenas 3D animadas (Three.js / React Three Fiber) e
+micro-interacções com Framer Motion.
 
-Stack: Next.js 14 (App Router) + TypeScript + Tailwind CSS.
+Stack: Next.js 14 (App Router) + TypeScript + Tailwind CSS + Three.js +
+@react-three/fiber + @react-three/drei + framer-motion.
 
 ## Funcionalidades
 
@@ -11,8 +14,13 @@ Stack: Next.js 14 (App Router) + TypeScript + Tailwind CSS.
   dinheiro), com cor e moeda.
 - Registar despesas com data, categoria, conta e notas.
 - Filtrar despesas por conta, categoria e mês.
-- Resumo mensal: total, totais por conta, top categorias, despesas recentes,
-  saldo agregado estimado (saldo inicial − despesas).
+- Dashboard com:
+  - **Cena 3D** com orb central distorcido e formas a orbitar (uma por conta).
+  - **Gráfico 3D** de barras a animar para os totais por categoria do mês,
+    com auto-rotate.
+  - Totais por conta e despesas recentes com transições 3D.
+- **Burst 3D** ao adicionar uma despesa (partículas a girar em rotateX/Y/Z).
+- Page transitions com flip 3D em edições.
 - Exportar / importar JSON (backup local entre dispositivos).
 
 ## Desenvolvimento

--- a/simple-expenses/app/accounts/page.tsx
+++ b/simple-expenses/app/accounts/page.tsx
@@ -44,11 +44,24 @@ function Accounts() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Contas e cartões</h1>
         {!creating && (
-          <button onClick={() => setCreating(true)} className="btn-primary">
+          <button
+            onClick={() => setCreating(true)}
+            className="btn-primary hidden md:inline-flex"
+          >
             Nova conta
           </button>
         )}
       </div>
+      {!creating && (
+        <button
+          onClick={() => setCreating(true)}
+          className="fab"
+          aria-label="Nova conta"
+        >
+          <span className="text-2xl leading-none">+</span>
+          Conta
+        </button>
+      )}
 
       <AnimatePresence>
         {creating && (

--- a/simple-expenses/app/accounts/page.tsx
+++ b/simple-expenses/app/accounts/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { ClientOnly } from "@/components/ClientOnly";
 import { AccountForm } from "@/components/AccountForm";
 import { useAppData, accountActions } from "@/lib/storage";
@@ -20,14 +21,13 @@ function Accounts() {
   const [creating, setCreating] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
 
-  const balances = useMemo(() => {
+  const totals = useMemo(() => {
     const map = new Map<string, number>();
-    for (const a of accounts) map.set(a.id, a.initialBalance);
     for (const e of expenses) {
-      map.set(e.accountId, (map.get(e.accountId) ?? 0) - e.amount);
+      map.set(e.accountId, (map.get(e.accountId) ?? 0) + e.amount);
     }
     return map;
-  }, [accounts, expenses]);
+  }, [expenses]);
 
   function remove(id: string, name: string) {
     if (
@@ -50,15 +50,23 @@ function Accounts() {
         )}
       </div>
 
-      {creating && (
-        <div className="card">
-          <h2 className="font-medium mb-3">Nova conta</h2>
-          <AccountForm
-            onDone={() => setCreating(false)}
-            onCancel={() => setCreating(false)}
-          />
-        </div>
-      )}
+      <AnimatePresence>
+        {creating && (
+          <motion.div
+            key="create"
+            initial={{ opacity: 0, y: -8, height: 0 }}
+            animate={{ opacity: 1, y: 0, height: "auto" }}
+            exit={{ opacity: 0, y: -8, height: 0 }}
+            className="card overflow-hidden"
+          >
+            <h2 className="font-medium mb-3">Nova conta</h2>
+            <AccountForm
+              onDone={() => setCreating(false)}
+              onCancel={() => setCreating(false)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {accounts.length === 0 && !creating && (
         <div className="card text-sm text-ink-600 dark:text-ink-400">
@@ -67,57 +75,81 @@ function Accounts() {
       )}
 
       <div className="grid gap-3 sm:grid-cols-2">
-        {accounts.map((a) => {
+        {accounts.map((a, i) => {
           const isEditing = editingId === a.id;
           const count = expenses.filter((e) => e.accountId === a.id).length;
-          const balance = balances.get(a.id) ?? a.initialBalance;
+          const total = totals.get(a.id) ?? 0;
           return (
-            <div key={a.id} className="card">
-              {isEditing ? (
-                <AccountForm
-                  account={a}
-                  onDone={() => setEditingId(null)}
-                  onCancel={() => setEditingId(null)}
-                />
-              ) : (
-                <>
-                  <div className="flex items-start gap-3">
-                    <span
-                      className="h-10 w-10 rounded-full shrink-0"
-                      style={{ backgroundColor: a.color }}
+            <motion.div
+              key={a.id}
+              initial={{ opacity: 0, y: 16, rotateX: -10 }}
+              animate={{ opacity: 1, y: 0, rotateX: 0 }}
+              transition={{ delay: i * 0.05, duration: 0.45 }}
+              whileHover={!isEditing ? { y: -4, rotateX: 4, rotateY: -3 } : {}}
+              style={{ transformPerspective: 900 }}
+              className="card"
+            >
+              <AnimatePresence mode="wait" initial={false}>
+                {isEditing ? (
+                  <motion.div
+                    key="edit"
+                    initial={{ opacity: 0, rotateY: 90 }}
+                    animate={{ opacity: 1, rotateY: 0 }}
+                    exit={{ opacity: 0, rotateY: -90 }}
+                    transition={{ duration: 0.35 }}
+                  >
+                    <AccountForm
+                      account={a}
+                      onDone={() => setEditingId(null)}
+                      onCancel={() => setEditingId(null)}
                     />
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium truncate">{a.name}</div>
-                      <div className="text-xs text-ink-600 dark:text-ink-400">
-                        {ACCOUNT_TYPE_LABELS[a.type]} · {a.currency}
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="view"
+                    initial={{ opacity: 0, rotateY: -90 }}
+                    animate={{ opacity: 1, rotateY: 0 }}
+                    exit={{ opacity: 0, rotateY: 90 }}
+                    transition={{ duration: 0.35 }}
+                  >
+                    <div className="flex items-start gap-3">
+                      <span
+                        className="h-10 w-10 rounded-full shrink-0 shadow-inner"
+                        style={{ backgroundColor: a.color }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">{a.name}</div>
+                        <div className="text-xs text-ink-600 dark:text-ink-400">
+                          {ACCOUNT_TYPE_LABELS[a.type]} · {a.currency}
+                        </div>
+                      </div>
+                      <div className="text-right shrink-0">
+                        <div className="font-semibold tabular-nums">
+                          {formatMoney(total, a.currency)}
+                        </div>
+                        <div className="text-xs text-ink-600 dark:text-ink-400">
+                          {count} despesas
+                        </div>
                       </div>
                     </div>
-                    <div className="text-right shrink-0">
-                      <div className="font-semibold">
-                        {formatMoney(balance, a.currency)}
-                      </div>
-                      <div className="text-xs text-ink-600 dark:text-ink-400">
-                        {count} despesas
-                      </div>
+                    <div className="flex gap-2 mt-4">
+                      <button
+                        className="btn-ghost"
+                        onClick={() => setEditingId(a.id)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        className="btn-danger"
+                        onClick={() => remove(a.id, a.name)}
+                      >
+                        Apagar
+                      </button>
                     </div>
-                  </div>
-                  <div className="flex gap-2 mt-4">
-                    <button
-                      className="btn-ghost"
-                      onClick={() => setEditingId(a.id)}
-                    >
-                      Editar
-                    </button>
-                    <button
-                      className="btn-danger"
-                      onClick={() => remove(a.id, a.name)}
-                    >
-                      Apagar
-                    </button>
-                  </div>
-                </>
-              )}
-            </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </motion.div>
           );
         })}
       </div>

--- a/simple-expenses/app/expenses/page.tsx
+++ b/simple-expenses/app/expenses/page.tsx
@@ -52,11 +52,24 @@ function Expenses() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Despesas</h1>
         {!creating && accounts.length > 0 && (
-          <button onClick={() => setCreating(true)} className="btn-primary">
+          <button
+            onClick={() => setCreating(true)}
+            className="btn-primary hidden md:inline-flex"
+          >
             Nova despesa
           </button>
         )}
       </div>
+      {!creating && accounts.length > 0 && (
+        <button
+          onClick={() => setCreating(true)}
+          className="fab"
+          aria-label="Nova despesa"
+        >
+          <span className="text-2xl leading-none">+</span>
+          Despesa
+        </button>
+      )}
 
       <AnimatePresence>
         {creating && (
@@ -207,14 +220,13 @@ function Expenses() {
                         </div>
                         <div className="flex gap-1 mt-1 justify-end">
                           <button
-                            className="text-xs text-ink-600 hover:text-ink-900 dark:text-ink-300"
+                            className="px-2 py-1 -mr-1 text-xs text-ink-600 hover:text-ink-900 dark:text-ink-300 rounded touch-manipulation"
                             onClick={() => setEditingId(e.id)}
                           >
                             editar
                           </button>
-                          <span className="text-ink-400">·</span>
                           <button
-                            className="text-xs text-red-600 hover:text-red-700"
+                            className="px-2 py-1 text-xs text-red-600 hover:text-red-700 rounded touch-manipulation"
                             onClick={() => remove(e.id, e.description)}
                           >
                             apagar

--- a/simple-expenses/app/expenses/page.tsx
+++ b/simple-expenses/app/expenses/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { ClientOnly } from "@/components/ClientOnly";
 import { ExpenseForm } from "@/components/ExpenseForm";
+import { Burst } from "@/components/Burst";
 import { useAppData, expenseActions } from "@/lib/storage";
 import { formatDate, formatMoney, monthKey } from "@/lib/format";
 import { DEFAULT_CATEGORIES } from "@/lib/types";
@@ -19,6 +21,7 @@ function Expenses() {
   const { accounts, expenses } = useAppData();
   const [creating, setCreating] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
+  const [burstTrigger, setBurstTrigger] = useState(0);
 
   const [accountFilter, setAccountFilter] = useState<string>("all");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
@@ -45,6 +48,7 @@ function Expenses() {
 
   return (
     <div className="space-y-5">
+      <Burst trigger={burstTrigger} />
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-semibold">Despesas</h1>
         {!creating && accounts.length > 0 && (
@@ -54,16 +58,29 @@ function Expenses() {
         )}
       </div>
 
-      {creating && (
-        <div className="card">
-          <h2 className="font-medium mb-3">Nova despesa</h2>
-          <ExpenseForm
-            accounts={accounts}
-            onDone={() => setCreating(false)}
-            onCancel={() => setCreating(false)}
-          />
-        </div>
-      )}
+      <AnimatePresence>
+        {creating && (
+          <motion.div
+            key="create-expense"
+            initial={{ opacity: 0, rotateX: -20, y: -10, height: 0 }}
+            animate={{ opacity: 1, rotateX: 0, y: 0, height: "auto" }}
+            exit={{ opacity: 0, rotateX: -20, y: -10, height: 0 }}
+            transition={{ duration: 0.4 }}
+            style={{ transformPerspective: 900 }}
+            className="card overflow-hidden"
+          >
+            <h2 className="font-medium mb-3">Nova despesa</h2>
+            <ExpenseForm
+              accounts={accounts}
+              onDone={() => {
+                setCreating(false);
+                setBurstTrigger((t) => t + 1);
+              }}
+              onCancel={() => setCreating(false)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {accounts.length === 0 ? (
         <div className="card text-sm text-ink-600 dark:text-ink-400">
@@ -130,65 +147,84 @@ function Expenses() {
             </div>
           ) : (
             <div className="card divide-y divide-ink-200 dark:divide-ink-700">
-              {filtered.map((e) => {
-                const account = accounts.find((a) => a.id === e.accountId);
-                const isEditing = editingId === e.id;
-                if (isEditing) {
+              <AnimatePresence initial={false}>
+                {filtered.map((e, i) => {
+                  const account = accounts.find((a) => a.id === e.accountId);
+                  const isEditing = editingId === e.id;
+                  if (isEditing) {
+                    return (
+                      <motion.div
+                        key={e.id}
+                        initial={{ opacity: 0, rotateY: 90 }}
+                        animate={{ opacity: 1, rotateY: 0 }}
+                        exit={{ opacity: 0, rotateY: -90 }}
+                        transition={{ duration: 0.35 }}
+                        style={{ transformPerspective: 900 }}
+                        className="py-3 first:pt-0 last:pb-0"
+                      >
+                        <ExpenseForm
+                          accounts={accounts}
+                          expense={e}
+                          onDone={() => setEditingId(null)}
+                          onCancel={() => setEditingId(null)}
+                        />
+                      </motion.div>
+                    );
+                  }
                   return (
-                    <div key={e.id} className="py-3 first:pt-0 last:pb-0">
-                      <ExpenseForm
-                        accounts={accounts}
-                        expense={e}
-                        onDone={() => setEditingId(null)}
-                        onCancel={() => setEditingId(null)}
+                    <motion.div
+                      key={e.id}
+                      layout
+                      initial={{ opacity: 0, x: -16, rotateY: -25 }}
+                      animate={{ opacity: 1, x: 0, rotateY: 0 }}
+                      exit={{ opacity: 0, x: 16, rotateY: 25 }}
+                      transition={{
+                        delay: Math.min(i * 0.03, 0.3),
+                        duration: 0.35,
+                      }}
+                      style={{ transformPerspective: 900 }}
+                      className="py-3 first:pt-0 last:pb-0 flex items-start gap-3"
+                    >
+                      <span
+                        className="h-3 w-3 rounded-full mt-1.5 shrink-0"
+                        style={{ backgroundColor: account?.color ?? "#94a3b8" }}
                       />
-                    </div>
-                  );
-                }
-                return (
-                  <div
-                    key={e.id}
-                    className="py-3 first:pt-0 last:pb-0 flex items-start gap-3"
-                  >
-                    <span
-                      className="h-3 w-3 rounded-full mt-1.5 shrink-0"
-                      style={{ backgroundColor: account?.color ?? "#94a3b8" }}
-                    />
-                    <div className="flex-1 min-w-0">
-                      <div className="font-medium truncate">{e.description}</div>
-                      <div className="text-xs text-ink-600 dark:text-ink-400">
-                        {account?.name ?? "—"} · {e.category} ·{" "}
-                        {formatDate(e.date)}
-                      </div>
-                      {e.notes && (
-                        <div className="text-xs mt-1 text-ink-600 dark:text-ink-400">
-                          {e.notes}
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">{e.description}</div>
+                        <div className="text-xs text-ink-600 dark:text-ink-400">
+                          {account?.name ?? "—"} · {e.category} ·{" "}
+                          {formatDate(e.date)}
                         </div>
-                      )}
-                    </div>
-                    <div className="text-right shrink-0">
-                      <div className="font-medium">
-                        {formatMoney(e.amount, account?.currency)}
+                        {e.notes && (
+                          <div className="text-xs mt-1 text-ink-600 dark:text-ink-400">
+                            {e.notes}
+                          </div>
+                        )}
                       </div>
-                      <div className="flex gap-1 mt-1 justify-end">
-                        <button
-                          className="text-xs text-ink-600 hover:text-ink-900 dark:text-ink-300"
-                          onClick={() => setEditingId(e.id)}
-                        >
-                          editar
-                        </button>
-                        <span className="text-ink-400">·</span>
-                        <button
-                          className="text-xs text-red-600 hover:text-red-700"
-                          onClick={() => remove(e.id, e.description)}
-                        >
-                          apagar
-                        </button>
+                      <div className="text-right shrink-0">
+                        <div className="font-medium tabular-nums">
+                          {formatMoney(e.amount, account?.currency)}
+                        </div>
+                        <div className="flex gap-1 mt-1 justify-end">
+                          <button
+                            className="text-xs text-ink-600 hover:text-ink-900 dark:text-ink-300"
+                            onClick={() => setEditingId(e.id)}
+                          >
+                            editar
+                          </button>
+                          <span className="text-ink-400">·</span>
+                          <button
+                            className="text-xs text-red-600 hover:text-red-700"
+                            onClick={() => remove(e.id, e.description)}
+                          >
+                            apagar
+                          </button>
+                        </div>
                       </div>
-                    </div>
-                  </div>
-                );
-              })}
+                    </motion.div>
+                  );
+                })}
+              </AnimatePresence>
             </div>
           )}
         </>

--- a/simple-expenses/app/globals.css
+++ b/simple-expenses/app/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   color-scheme: light dark;
+  --safe-bottom: env(safe-area-inset-bottom);
 }
 
 html,
@@ -11,8 +12,14 @@ body {
   height: 100%;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent;
+}
+
 body {
   @apply bg-ink-50 text-ink-900 antialiased;
+  overscroll-behavior-y: none;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -21,8 +28,13 @@ body {
   }
 }
 
+button,
+a {
+  touch-action: manipulation;
+}
+
 .btn {
-  @apply inline-flex items-center justify-center rounded-md px-3 py-2 text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ink-50 disabled:opacity-50 disabled:cursor-not-allowed;
+  @apply inline-flex items-center justify-center rounded-lg px-4 min-h-[44px] text-sm font-medium transition focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-ink-50 disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98];
 }
 
 .btn-primary {
@@ -40,7 +52,12 @@ body {
 .input,
 .select,
 .textarea {
-  @apply w-full rounded-md border border-ink-200 bg-white px-3 py-2 text-sm text-ink-900 shadow-sm focus:border-ink-800 focus:outline-none focus:ring-1 focus:ring-ink-800 dark:bg-ink-800 dark:border-ink-600 dark:text-ink-100;
+  @apply w-full rounded-lg border border-ink-200 bg-white px-3 py-2.5 text-base sm:text-sm text-ink-900 shadow-sm focus:border-ink-800 focus:outline-none focus:ring-1 focus:ring-ink-800 dark:bg-ink-800 dark:border-ink-600 dark:text-ink-100;
+  min-height: 44px;
+}
+
+.textarea {
+  min-height: 72px;
 }
 
 .label {
@@ -48,5 +65,10 @@ body {
 }
 
 .card {
-  @apply rounded-xl border border-ink-200 bg-white p-5 shadow-sm dark:bg-ink-800 dark:border-ink-600;
+  @apply rounded-xl border border-ink-200 bg-white p-4 sm:p-5 shadow-sm dark:bg-ink-800 dark:border-ink-600;
+}
+
+.fab {
+  @apply md:hidden fixed right-4 z-40 inline-flex items-center justify-center gap-2 rounded-full bg-ink-900 text-white shadow-lg shadow-ink-900/20 px-5 h-14 text-sm font-medium active:scale-95 transition;
+  bottom: calc(env(safe-area-inset-bottom) + 76px);
 }

--- a/simple-expenses/app/layout.tsx
+++ b/simple-expenses/app/layout.tsx
@@ -1,17 +1,28 @@
 import type { Metadata, Viewport } from "next";
 import Link from "next/link";
 import "./globals.css";
-import { NavLinks } from "@/components/NavLinks";
+import { BottomNav, NavLinks } from "@/components/NavLinks";
 
 export const metadata: Metadata = {
   title: "Simple Expenses",
   description: "Gestão simples de despesas em várias contas e cartões",
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Despesas",
+  },
 };
 
 export const viewport: Viewport = {
-  themeColor: "#0f172a",
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f8fafc" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f172a" },
+  ],
   width: "device-width",
   initialScale: 1,
+  viewportFit: "cover",
+  maximumScale: 5,
 };
 
 export default function RootLayout({
@@ -23,22 +34,38 @@ export default function RootLayout({
     <html lang="pt-PT">
       <body>
         <div className="min-h-screen flex flex-col">
-          <header className="border-b border-ink-200 bg-white/70 backdrop-blur dark:bg-ink-900/70 dark:border-ink-800">
+          <header
+            className="sticky top-0 z-30 border-b border-ink-200 bg-white/80 backdrop-blur dark:bg-ink-900/80 dark:border-ink-800"
+            style={{ paddingTop: "env(safe-area-inset-top)" }}
+          >
             <div className="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between gap-4">
-              <Link href="/" className="font-semibold tracking-tight">
+              <Link
+                href="/"
+                className="font-semibold tracking-tight touch-manipulation"
+              >
                 Simple Expenses
               </Link>
               <NavLinks />
             </div>
           </header>
-          <main className="flex-1">
-            <div className="mx-auto max-w-5xl px-4 py-6 sm:py-8">{children}</div>
+          <main
+            className="flex-1"
+            style={{
+              paddingLeft: "env(safe-area-inset-left)",
+              paddingRight: "env(safe-area-inset-right)",
+            }}
+          >
+            <div className="mx-auto max-w-5xl px-4 py-5 sm:py-8 pb-28 md:pb-8">
+              {children}
+            </div>
           </main>
-          <footer className="border-t border-ink-200 dark:border-ink-800 py-4">
+          <footer className="hidden md:block border-t border-ink-200 dark:border-ink-800 py-4">
             <div className="mx-auto max-w-5xl px-4 text-xs text-ink-600 dark:text-ink-400">
-              Dados guardados localmente no browser. Use Definições para exportar/importar.
+              Dados guardados localmente no browser. Use Definições para
+              exportar/importar.
             </div>
           </footer>
+          <BottomNav />
         </div>
       </body>
     </html>

--- a/simple-expenses/app/page.tsx
+++ b/simple-expenses/app/page.tsx
@@ -71,7 +71,7 @@ function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <section className="relative overflow-hidden rounded-2xl border border-ink-200 dark:border-ink-700 bg-gradient-to-br from-ink-100 via-white to-ink-50 dark:from-ink-800 dark:via-ink-900 dark:to-ink-800">
+      <section className="relative overflow-hidden rounded-2xl border border-ink-200 dark:border-ink-700 bg-gradient-to-br from-ink-100 via-white to-ink-50 dark:from-ink-800 dark:via-ink-900 dark:to-ink-800 min-h-[18rem] sm:min-h-[22rem]">
         <div className="absolute inset-0">
           <HeroScene
             accounts={accounts}
@@ -79,19 +79,19 @@ function Dashboard() {
             allTimeSpend={totalAll}
           />
         </div>
-        <div className="relative z-10 p-6 sm:p-8 pointer-events-none">
+        <div className="relative z-10 p-5 sm:p-8 pointer-events-none">
           <motion.div
             initial={{ opacity: 0, y: 12 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6 }}
           >
-            <div className="text-xs uppercase tracking-widest text-ink-600 dark:text-ink-300">
+            <div className="text-[11px] sm:text-xs uppercase tracking-widest text-ink-600 dark:text-ink-300">
               {monthLabel(thisMonth)}
             </div>
-            <div className="mt-1 text-4xl sm:text-5xl font-semibold tabular-nums">
+            <div className="mt-1 text-3xl sm:text-5xl font-semibold tabular-nums">
               {formatMoney(monthTotal)}
             </div>
-            <div className="mt-2 text-sm text-ink-600 dark:text-ink-300">
+            <div className="mt-2 text-xs sm:text-sm text-ink-600 dark:text-ink-300">
               {monthExpenses.length} despesas este mês ·{" "}
               {formatMoney(totalAll)} no total
             </div>

--- a/simple-expenses/app/page.tsx
+++ b/simple-expenses/app/page.tsx
@@ -1,10 +1,23 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import Link from "next/link";
+import { motion } from "framer-motion";
 import { useMemo } from "react";
 import { ClientOnly } from "@/components/ClientOnly";
 import { useAppData } from "@/lib/storage";
 import { formatMoney, monthKey, monthLabel } from "@/lib/format";
+
+const HeroScene = dynamic(
+  () => import("@/components/three/HeroScene").then((m) => m.HeroScene),
+  { ssr: false, loading: () => <div className="h-64 sm:h-80" /> },
+);
+
+const CategoryBars3D = dynamic(
+  () =>
+    import("@/components/three/CategoryBars3D").then((m) => m.CategoryBars3D),
+  { ssr: false, loading: () => <div className="h-64" /> },
+);
 
 export default function DashboardPage() {
   return (
@@ -17,18 +30,10 @@ export default function DashboardPage() {
 function Dashboard() {
   const { accounts, expenses } = useAppData();
 
-  const totals = useMemo(() => {
-    const byAccount = new Map<string, number>();
-    for (const a of accounts) byAccount.set(a.id, a.initialBalance);
-    for (const e of expenses) {
-      byAccount.set(e.accountId, (byAccount.get(e.accountId) ?? 0) - e.amount);
-    }
-    return byAccount;
-  }, [accounts, expenses]);
-
   const thisMonth = monthKey(new Date().toISOString());
   const monthExpenses = expenses.filter((e) => monthKey(e.date) === thisMonth);
   const monthTotal = monthExpenses.reduce((s, e) => s + e.amount, 0);
+  const totalAll = expenses.reduce((s, e) => s + e.amount, 0);
 
   const byCategory = useMemo(() => {
     const map = new Map<string, number>();
@@ -36,6 +41,14 @@ function Dashboard() {
       map.set(e.category, (map.get(e.category) ?? 0) + e.amount);
     }
     return [...map.entries()].sort((a, b) => b[1] - a[1]);
+  }, [monthExpenses]);
+
+  const byAccountMonth = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of monthExpenses) {
+      map.set(e.accountId, (map.get(e.accountId) ?? 0) + e.amount);
+    }
+    return map;
   }, [monthExpenses]);
 
   const recent = [...expenses]
@@ -58,74 +71,68 @@ function Dashboard() {
 
   return (
     <div className="space-y-6">
-      <section>
-        <h1 className="text-xl font-semibold mb-3">Resumo</h1>
-        <div className="grid gap-3 sm:grid-cols-3">
-          <div className="card">
-            <div className="text-xs uppercase text-ink-600 dark:text-ink-400">
+      <section className="relative overflow-hidden rounded-2xl border border-ink-200 dark:border-ink-700 bg-gradient-to-br from-ink-100 via-white to-ink-50 dark:from-ink-800 dark:via-ink-900 dark:to-ink-800">
+        <div className="absolute inset-0">
+          <HeroScene
+            accounts={accounts}
+            monthSpend={monthTotal}
+            allTimeSpend={totalAll}
+          />
+        </div>
+        <div className="relative z-10 p-6 sm:p-8 pointer-events-none">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6 }}
+          >
+            <div className="text-xs uppercase tracking-widest text-ink-600 dark:text-ink-300">
               {monthLabel(thisMonth)}
             </div>
-            <div className="text-2xl font-semibold mt-1">
+            <div className="mt-1 text-4xl sm:text-5xl font-semibold tabular-nums">
               {formatMoney(monthTotal)}
             </div>
-            <div className="text-xs text-ink-600 dark:text-ink-400 mt-1">
-              {monthExpenses.length} despesas este mês
+            <div className="mt-2 text-sm text-ink-600 dark:text-ink-300">
+              {monthExpenses.length} despesas este mês ·{" "}
+              {formatMoney(totalAll)} no total
             </div>
-          </div>
-          <div className="card">
-            <div className="text-xs uppercase text-ink-600 dark:text-ink-400">
-              Contas
-            </div>
-            <div className="text-2xl font-semibold mt-1">{accounts.length}</div>
-            <div className="text-xs text-ink-600 dark:text-ink-400 mt-1">
-              {expenses.length} despesas no total
-            </div>
-          </div>
-          <div className="card">
-            <div className="text-xs uppercase text-ink-600 dark:text-ink-400">
-              Saldo agregado (estimado)
-            </div>
-            <div className="text-2xl font-semibold mt-1">
-              {formatMoney(
-                accounts.reduce(
-                  (s, a) => s + (totals.get(a.id) ?? a.initialBalance),
-                  0,
-                ),
-              )}
-            </div>
-            <div className="text-xs text-ink-600 dark:text-ink-400 mt-1">
-              saldo inicial − despesas
-            </div>
-          </div>
+          </motion.div>
         </div>
       </section>
 
       <section>
         <h2 className="text-lg font-semibold mb-3">Por conta / cartão</h2>
         <div className="grid gap-3 sm:grid-cols-2">
-          {accounts.map((a) => {
-            const balance = totals.get(a.id) ?? a.initialBalance;
-            const monthSpent = monthExpenses
+          {accounts.map((a, i) => {
+            const monthSpent = byAccountMonth.get(a.id) ?? 0;
+            const total = expenses
               .filter((e) => e.accountId === a.id)
               .reduce((s, e) => s + e.amount, 0);
             return (
-              <div key={a.id} className="card flex items-start gap-3">
+              <motion.div
+                key={a.id}
+                initial={{ opacity: 0, y: 14, rotateX: -8 }}
+                animate={{ opacity: 1, y: 0, rotateX: 0 }}
+                transition={{ delay: i * 0.05, duration: 0.45 }}
+                whileHover={{ y: -3, rotateX: 4, rotateY: -2 }}
+                style={{ transformPerspective: 800 }}
+                className="card flex items-start gap-3"
+              >
                 <span
-                  className="h-10 w-10 rounded-full shrink-0"
+                  className="h-10 w-10 rounded-full shrink-0 shadow-inner"
                   style={{ backgroundColor: a.color }}
                 />
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between gap-2">
                     <div className="font-medium truncate">{a.name}</div>
-                    <div className="text-sm font-semibold">
-                      {formatMoney(balance, a.currency)}
+                    <div className="text-sm font-semibold tabular-nums">
+                      {formatMoney(monthSpent, a.currency)}
                     </div>
                   </div>
                   <div className="text-xs text-ink-600 dark:text-ink-400 mt-1">
-                    Este mês: {formatMoney(monthSpent, a.currency)}
+                    Total acumulado: {formatMoney(total, a.currency)}
                   </div>
                 </div>
-              </div>
+              </motion.div>
             );
           })}
         </div>
@@ -134,16 +141,21 @@ function Dashboard() {
       {byCategory.length > 0 && (
         <section>
           <h2 className="text-lg font-semibold mb-3">Categorias deste mês</h2>
-          <div className="card divide-y divide-ink-200 dark:divide-ink-700">
-            {byCategory.map(([cat, value]) => (
-              <div
-                key={cat}
-                className="flex items-center justify-between py-2 first:pt-0 last:pb-0"
-              >
-                <span>{cat}</span>
-                <span className="font-medium">{formatMoney(value)}</span>
-              </div>
-            ))}
+          <div className="card overflow-hidden p-0">
+            <div className="h-64">
+              <CategoryBars3D data={byCategory} />
+            </div>
+            <div className="border-t border-ink-200 dark:border-ink-700 p-4 grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+              {byCategory.map(([cat, value]) => (
+                <div
+                  key={cat}
+                  className="flex items-center justify-between tabular-nums"
+                >
+                  <span className="truncate">{cat}</span>
+                  <span className="font-medium">{formatMoney(value)}</span>
+                </div>
+              ))}
+            </div>
           </div>
         </section>
       )}
@@ -160,11 +172,14 @@ function Dashboard() {
             </Link>
           </div>
           <div className="card divide-y divide-ink-200 dark:divide-ink-700">
-            {recent.map((e) => {
+            {recent.map((e, i) => {
               const account = accounts.find((a) => a.id === e.accountId);
               return (
-                <div
+                <motion.div
                   key={e.id}
+                  initial={{ opacity: 0, x: -12 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ delay: i * 0.04 }}
                   className="flex items-center justify-between py-2 first:pt-0 last:pb-0 gap-3"
                 >
                   <div className="min-w-0">
@@ -174,14 +189,14 @@ function Dashboard() {
                     </div>
                   </div>
                   <div className="text-right shrink-0">
-                    <div className="font-medium">
+                    <div className="font-medium tabular-nums">
                       {formatMoney(e.amount, account?.currency)}
                     </div>
                     <div className="text-xs text-ink-600 dark:text-ink-400">
                       {e.date}
                     </div>
                   </div>
-                </div>
+                </motion.div>
               );
             })}
           </div>

--- a/simple-expenses/components/AccountForm.tsx
+++ b/simple-expenses/components/AccountForm.tsx
@@ -18,9 +18,6 @@ interface Props {
 export function AccountForm({ account, onDone, onCancel }: Props) {
   const [name, setName] = useState(account?.name ?? "");
   const [type, setType] = useState<AccountType>(account?.type ?? "checking");
-  const [initialBalance, setInitialBalance] = useState(
-    account?.initialBalance?.toString() ?? "0",
-  );
   const [currency, setCurrency] = useState(account?.currency ?? "EUR");
   const [color, setColor] = useState(account?.color ?? ACCOUNT_COLORS[0]);
 
@@ -29,7 +26,6 @@ export function AccountForm({ account, onDone, onCancel }: Props) {
     const payload = {
       name: name.trim(),
       type,
-      initialBalance: Number(initialBalance) || 0,
       currency: currency.trim().toUpperCase() || "EUR",
       color,
     };
@@ -78,16 +74,6 @@ export function AccountForm({ account, onDone, onCancel }: Props) {
             maxLength={3}
           />
         </div>
-      </div>
-      <div>
-        <label className="label">Saldo inicial</label>
-        <input
-          className="input"
-          type="number"
-          step="0.01"
-          value={initialBalance}
-          onChange={(e) => setInitialBalance(e.target.value)}
-        />
       </div>
       <div>
         <label className="label">Cor</label>

--- a/simple-expenses/components/Burst.tsx
+++ b/simple-expenses/components/Burst.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+const SHAPES = ["€", "💸", "✨", "★", "•"];
+
+interface Particle {
+  id: number;
+  x: number;
+  y: number;
+  rot: number;
+  rotEnd: number;
+  scale: number;
+  symbol: string;
+  color: string;
+}
+
+const PALETTE = ["#0ea5e9", "#22c55e", "#f97316", "#a855f7", "#ec4899"];
+
+function makeParticles(count = 22): Particle[] {
+  return Array.from({ length: count }, (_, i) => {
+    const angle = (i / count) * Math.PI * 2 + Math.random() * 0.5;
+    const radius = 80 + Math.random() * 140;
+    return {
+      id: i,
+      x: Math.cos(angle) * radius,
+      y: Math.sin(angle) * radius - 60,
+      rot: Math.random() * 360,
+      rotEnd: Math.random() * 720 - 360,
+      scale: 0.6 + Math.random() * 0.9,
+      symbol: SHAPES[i % SHAPES.length],
+      color: PALETTE[i % PALETTE.length],
+    };
+  });
+}
+
+export function Burst({ trigger }: { trigger: number }) {
+  const [particles, setParticles] = useState<Particle[]>([]);
+
+  useEffect(() => {
+    if (trigger === 0) return;
+    setParticles(makeParticles());
+    const t = setTimeout(() => setParticles([]), 1200);
+    return () => clearTimeout(t);
+  }, [trigger]);
+
+  return (
+    <div
+      className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center"
+      style={{ perspective: 800 }}
+    >
+      <AnimatePresence>
+        {particles.map((p) => (
+          <motion.div
+            key={`${trigger}-${p.id}`}
+            initial={{
+              x: 0,
+              y: 0,
+              rotateX: 0,
+              rotateY: 0,
+              rotateZ: p.rot,
+              scale: 0.2,
+              opacity: 0,
+            }}
+            animate={{
+              x: p.x,
+              y: p.y,
+              rotateX: p.rotEnd,
+              rotateY: p.rotEnd * 0.6,
+              rotateZ: p.rot + p.rotEnd,
+              scale: p.scale,
+              opacity: [0, 1, 1, 0],
+            }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 1.0, ease: [0.2, 0.8, 0.4, 1] }}
+            className="absolute text-2xl font-bold select-none"
+            style={{
+              color: p.color,
+              textShadow: "0 2px 8px rgba(0,0,0,0.15)",
+              transformStyle: "preserve-3d",
+            }}
+          >
+            {p.symbol}
+          </motion.div>
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/simple-expenses/components/NavLinks.tsx
+++ b/simple-expenses/components/NavLinks.tsx
@@ -4,16 +4,16 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const links = [
-  { href: "/", label: "Resumo" },
-  { href: "/accounts", label: "Contas" },
-  { href: "/expenses", label: "Despesas" },
-  { href: "/settings", label: "Definições" },
+  { href: "/", label: "Resumo", icon: HomeIcon },
+  { href: "/accounts", label: "Contas", icon: WalletIcon },
+  { href: "/expenses", label: "Despesas", icon: ListIcon },
+  { href: "/settings", label: "Definições", icon: CogIcon },
 ];
 
 export function NavLinks() {
   const pathname = usePathname();
   return (
-    <nav className="flex items-center gap-1 text-sm">
+    <nav className="hidden md:flex items-center gap-1 text-sm">
       {links.map((l) => {
         const active = pathname === l.href;
         return (
@@ -21,7 +21,7 @@ export function NavLinks() {
             key={l.href}
             href={l.href}
             className={
-              "rounded-md px-3 py-1.5 transition " +
+              "rounded-md px-3 py-1.5 transition touch-manipulation " +
               (active
                 ? "bg-ink-900 text-white dark:bg-ink-100 dark:text-ink-900"
                 : "text-ink-600 hover:bg-ink-100 dark:text-ink-200 dark:hover:bg-ink-800")
@@ -32,5 +32,84 @@ export function NavLinks() {
         );
       })}
     </nav>
+  );
+}
+
+export function BottomNav() {
+  const pathname = usePathname();
+  return (
+    <nav
+      className="md:hidden fixed bottom-0 inset-x-0 z-40 border-t border-ink-200 dark:border-ink-700 bg-white/90 dark:bg-ink-900/90 backdrop-blur"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <ul className="grid grid-cols-4">
+        {links.map((l) => {
+          const active = pathname === l.href;
+          const Icon = l.icon;
+          return (
+            <li key={l.href}>
+              <Link
+                href={l.href}
+                className={
+                  "flex flex-col items-center justify-center gap-0.5 py-2.5 text-[11px] touch-manipulation transition " +
+                  (active
+                    ? "text-ink-900 dark:text-ink-100"
+                    : "text-ink-400 dark:text-ink-400")
+                }
+              >
+                <Icon
+                  className={
+                    "h-6 w-6 " +
+                    (active ? "scale-110" : "")
+                  }
+                />
+                <span>{l.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}
+
+function HomeIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 11l9-8 9 8" />
+      <path d="M5 10v10a1 1 0 0 0 1 1h4v-6h4v6h4a1 1 0 0 0 1-1V10" />
+    </svg>
+  );
+}
+
+function WalletIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M3 7a2 2 0 0 1 2-2h13a1 1 0 0 1 1 1v3" />
+      <path d="M3 7v11a2 2 0 0 0 2 2h15a1 1 0 0 0 1-1v-4" />
+      <path d="M22 12h-5a2 2 0 0 0 0 4h5z" />
+    </svg>
+  );
+}
+
+function ListIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <path d="M8 6h13" />
+      <path d="M8 12h13" />
+      <path d="M8 18h13" />
+      <circle cx="4" cy="6" r="1" />
+      <circle cx="4" cy="12" r="1" />
+      <circle cx="4" cy="18" r="1" />
+    </svg>
+  );
+}
+
+function CogIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" {...props}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1.1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1A2 2 0 1 1 4.3 17l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1.1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3H9a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8V9a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+    </svg>
   );
 }

--- a/simple-expenses/components/three/CategoryBars3D.tsx
+++ b/simple-expenses/components/three/CategoryBars3D.tsx
@@ -33,9 +33,9 @@ export function CategoryBars3D({ data }: Props) {
 
   return (
     <Canvas
-      dpr={[1, 2]}
+      dpr={[1, 1.5]}
       camera={{ position: [0, 3.5, 6.5], fov: 40 }}
-      gl={{ antialias: true, alpha: true }}
+      gl={{ antialias: true, alpha: true, powerPreference: "low-power" }}
     >
       <Suspense fallback={null}>
         <ambientLight intensity={0.6} />

--- a/simple-expenses/components/three/CategoryBars3D.tsx
+++ b/simple-expenses/components/three/CategoryBars3D.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { OrbitControls, Text } from "@react-three/drei";
+import { Suspense, useMemo, useRef } from "react";
+import * as THREE from "three";
+
+const CATEGORY_COLORS: Record<string, string> = {
+  Alimentação: "#22c55e",
+  Transportes: "#0ea5e9",
+  Casa: "#f97316",
+  Saúde: "#ef4444",
+  Lazer: "#a855f7",
+  Educação: "#14b8a6",
+  Compras: "#ec4899",
+  Subscrições: "#eab308",
+  Outros: "#94a3b8",
+};
+
+interface Props {
+  data: [string, number][];
+}
+
+export function CategoryBars3D({ data }: Props) {
+  const max = Math.max(1, ...data.map((d) => d[1]));
+  const scaled = data.slice(0, 9).map(([name, value], i) => ({
+    name,
+    value,
+    height: (value / max) * 3.6 + 0.05,
+    color: CATEGORY_COLORS[name] ?? "#475569",
+    x: (i - Math.min(8, data.length - 1) / 2) * 0.9,
+  }));
+
+  return (
+    <Canvas
+      dpr={[1, 2]}
+      camera={{ position: [0, 3.5, 6.5], fov: 40 }}
+      gl={{ antialias: true, alpha: true }}
+    >
+      <Suspense fallback={null}>
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[5, 8, 4]} intensity={1} castShadow />
+        <pointLight position={[-4, 4, -3]} intensity={0.4} color="#0ea5e9" />
+        <SceneFloor />
+        {scaled.map((b) => (
+          <Bar key={b.name} {...b} />
+        ))}
+        <OrbitControls
+          enablePan={false}
+          enableZoom={false}
+          autoRotate
+          autoRotateSpeed={0.6}
+          minPolarAngle={Math.PI / 3.5}
+          maxPolarAngle={Math.PI / 2.2}
+        />
+      </Suspense>
+    </Canvas>
+  );
+}
+
+function SceneFloor() {
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.01, 0]} receiveShadow>
+      <planeGeometry args={[20, 20]} />
+      <meshStandardMaterial color="#0f172a" transparent opacity={0.06} />
+    </mesh>
+  );
+}
+
+function Bar({
+  name,
+  value,
+  height,
+  color,
+  x,
+}: {
+  name: string;
+  value: number;
+  height: number;
+  color: string;
+  x: number;
+}) {
+  const meshRef = useRef<THREE.Mesh>(null!);
+  const groupRef = useRef<THREE.Group>(null!);
+  const target = useRef(height);
+  target.current = height;
+
+  useFrame((_, delta) => {
+    const m = meshRef.current;
+    if (!m) return;
+    const cur = m.scale.y;
+    const next = cur + (target.current - cur) * Math.min(1, delta * 4);
+    m.scale.y = next;
+    m.position.y = next / 2;
+  });
+
+  return (
+    <group ref={groupRef} position={[x, 0, 0]}>
+      <mesh ref={meshRef} position={[0, 0, 0]} castShadow>
+        <boxGeometry args={[0.55, 1, 0.55]} />
+        <meshStandardMaterial
+          color={color}
+          metalness={0.35}
+          roughness={0.35}
+          emissive={color}
+          emissiveIntensity={0.08}
+        />
+      </mesh>
+      <Text
+        position={[0, -0.25, 0.4]}
+        rotation={[-Math.PI / 4, 0, 0]}
+        fontSize={0.18}
+        color="#475569"
+        anchorX="center"
+        anchorY="top"
+        maxWidth={1.2}
+      >
+        {name}
+      </Text>
+      <Text
+        position={[0, height + 0.25, 0]}
+        fontSize={0.22}
+        color="#0f172a"
+        anchorX="center"
+        anchorY="bottom"
+      >
+        {Math.round(value).toString()}
+      </Text>
+    </group>
+  );
+}

--- a/simple-expenses/components/three/HeroScene.tsx
+++ b/simple-expenses/components/three/HeroScene.tsx
@@ -17,9 +17,9 @@ export function HeroScene({ accounts, monthSpend, allTimeSpend }: Props) {
 
   return (
     <Canvas
-      dpr={[1, 2]}
+      dpr={[1, 1.5]}
       camera={{ position: [0, 0, 7], fov: 45 }}
-      gl={{ antialias: true, alpha: true }}
+      gl={{ antialias: true, alpha: true, powerPreference: "low-power" }}
       style={{ width: "100%", height: "100%" }}
     >
       <Suspense fallback={null}>

--- a/simple-expenses/components/three/HeroScene.tsx
+++ b/simple-expenses/components/three/HeroScene.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { Float, Environment, MeshDistortMaterial } from "@react-three/drei";
+import { Suspense, useMemo, useRef } from "react";
+import * as THREE from "three";
+import type { Account } from "@/lib/types";
+
+interface Props {
+  accounts: Account[];
+  monthSpend: number;
+  allTimeSpend: number;
+}
+
+export function HeroScene({ accounts, monthSpend, allTimeSpend }: Props) {
+  const intensity = Math.min(1, monthSpend / Math.max(1, allTimeSpend || 1));
+
+  return (
+    <Canvas
+      dpr={[1, 2]}
+      camera={{ position: [0, 0, 7], fov: 45 }}
+      gl={{ antialias: true, alpha: true }}
+      style={{ width: "100%", height: "100%" }}
+    >
+      <Suspense fallback={null}>
+        <ambientLight intensity={0.55} />
+        <directionalLight position={[5, 6, 5]} intensity={0.9} />
+        <pointLight position={[-5, -3, -2]} intensity={0.4} color="#a855f7" />
+        <Environment preset="city" />
+        <CenterOrb intensity={intensity} />
+        <AccountOrbs accounts={accounts} />
+      </Suspense>
+    </Canvas>
+  );
+}
+
+function CenterOrb({ intensity }: { intensity: number }) {
+  const ref = useRef<THREE.Mesh>(null!);
+  useFrame((state) => {
+    const t = state.clock.elapsedTime;
+    ref.current.rotation.y = t * 0.25;
+    ref.current.rotation.x = Math.sin(t * 0.3) * 0.2;
+  });
+  return (
+    <Float speed={1.2} rotationIntensity={0.4} floatIntensity={0.8}>
+      <mesh ref={ref}>
+        <icosahedronGeometry args={[1.1, 4]} />
+        <MeshDistortMaterial
+          color="#0f172a"
+          attach="material"
+          distort={0.35 + intensity * 0.25}
+          speed={1.6}
+          roughness={0.25}
+          metalness={0.6}
+        />
+      </mesh>
+    </Float>
+  );
+}
+
+function AccountOrbs({ accounts }: { accounts: Account[] }) {
+  const data = useMemo(() => {
+    const slice = accounts.slice(0, 8);
+    return slice.map((a, i) => {
+      const angle = (i / Math.max(1, slice.length)) * Math.PI * 2;
+      const radius = 2.6;
+      return {
+        id: a.id,
+        color: a.color,
+        position: [
+          Math.cos(angle) * radius,
+          Math.sin(angle * 1.3) * 0.6,
+          Math.sin(angle) * radius,
+        ] as [number, number, number],
+        speed: 0.4 + (i % 3) * 0.15,
+        scale: 0.35 + ((i * 13) % 5) * 0.04,
+        shape: i % 3,
+      };
+    });
+  }, [accounts]);
+
+  return (
+    <group>
+      {data.map((d) => (
+        <OrbitingShape key={d.id} {...d} />
+      ))}
+    </group>
+  );
+}
+
+function OrbitingShape({
+  position,
+  color,
+  speed,
+  scale,
+  shape,
+}: {
+  position: [number, number, number];
+  color: string;
+  speed: number;
+  scale: number;
+  shape: number;
+}) {
+  const ref = useRef<THREE.Mesh>(null!);
+  const start = useMemo(
+    () => Math.atan2(position[2], position[0]),
+    [position],
+  );
+  useFrame((state) => {
+    const t = state.clock.elapsedTime * speed + start;
+    const radius = Math.hypot(position[0], position[2]);
+    ref.current.position.x = Math.cos(t) * radius;
+    ref.current.position.z = Math.sin(t) * radius;
+    ref.current.position.y =
+      position[1] + Math.sin(state.clock.elapsedTime * 1.2 + start) * 0.25;
+    ref.current.rotation.x += 0.01;
+    ref.current.rotation.y += 0.012;
+  });
+  return (
+    <Float speed={1.4} rotationIntensity={0.6} floatIntensity={0.4}>
+      <mesh ref={ref} scale={scale}>
+        {shape === 0 && <icosahedronGeometry args={[1, 0]} />}
+        {shape === 1 && <torusGeometry args={[0.7, 0.28, 16, 48]} />}
+        {shape === 2 && <octahedronGeometry args={[1, 0]} />}
+        <meshStandardMaterial
+          color={color}
+          metalness={0.55}
+          roughness={0.25}
+          emissive={color}
+          emissiveIntensity={0.15}
+        />
+      </mesh>
+    </Float>
+  );
+}

--- a/simple-expenses/lib/types.ts
+++ b/simple-expenses/lib/types.ts
@@ -4,7 +4,6 @@ export interface Account {
   id: string;
   name: string;
   type: AccountType;
-  initialBalance: number;
   currency: string;
   color: string;
   createdAt: string;

--- a/simple-expenses/package-lock.json
+++ b/simple-expenses/package-lock.json
@@ -8,14 +8,19 @@
       "name": "simple-expenses",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^9.122.0",
+        "@react-three/fiber": "^8.18.0",
+        "framer-motion": "^11.18.2",
         "next": "14.2.18",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@types/node": "^22.9.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
+        "@types/three": "^0.184.0",
         "autoprefixer": "^10.4.20",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.15",
@@ -34,6 +39,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -72,6 +92,24 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@next/env": {
@@ -262,6 +300,195 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/three": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/three/-/three-9.7.5.tgz",
+      "integrity": "sha512-RxIsCoQfUqOS3POmhVHa1wdWS0wyHAUway73uRLp3GAL5U2iYVNdnzQsep6M2NZ994BlW8TcKuMtQHUqOsy6WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": ">=6.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "three": ">=0.126"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/drei": {
+      "version": "9.122.0",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.122.0.tgz",
+      "integrity": "sha512-SEO/F/rBCTjlLez7WAlpys+iGe9hty4rNgjZvgkQeXFSiwqD4Hbk/wNHMAbdd8vprO2Aj81mihv4dF5bC7D0CA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@react-spring/three": "~9.7.5",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^2.9.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "react-composer": "^5.0.3",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.7.8",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.0",
+        "tunnel-rat": "^0.1.2",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^8",
+        "react": "^18",
+        "react-dom": "^18",
+        "three": ">=0.137"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -278,6 +505,18 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -288,18 +527,22 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -314,6 +557,59 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
       }
     },
     "node_modules/any-promise": {
@@ -381,6 +677,26 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.27",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
@@ -392,6 +708,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -454,6 +779,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -473,6 +822,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-2.10.1.tgz",
+      "integrity": "sha512-KnaKdcvkBJ1Irbrzl8XD6WtZltkRjp869Jx8c0ujs9K+9WD+1D7ryBsCiVqJYUqt6i/HR5FxT7RLASieUD+Q5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -549,6 +907,38 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -566,8 +956,16 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -582,6 +980,12 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.350",
@@ -650,6 +1054,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -675,6 +1085,33 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fsevents": {
@@ -715,6 +1152,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -733,6 +1176,38 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -796,6 +1271,39 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -811,6 +1319,15 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -844,6 +1361,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -853,6 +1380,21 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -867,6 +1409,21 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -998,7 +1555,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1012,6 +1568,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-parse": {
@@ -1223,6 +1788,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1256,6 +1848,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-composer": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/react-composer/-/react-composer-5.0.3.tgz",
+      "integrity": "sha512-1uWd07EME6XZvMfapwZmc7NgCZqDemcvicRi3wMJzXsQLvZ3L7fTHVyPy1bZdnWXM4iPjYuNE+uJ41MLKeTtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -1267,6 +1871,52 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -1290,6 +1940,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -1358,6 +2017,27 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1366,6 +2046,32 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -1434,6 +2140,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
@@ -1494,6 +2209,45 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.7.8.tgz",
+      "integrity": "sha512-BGEZTOIC14U0XIRw3tO4jY7IjP7n7v24nv9JXS1CyeVRWOCkcOMhRnmENUjuV39gktAw4Ofhr0OvIAiTspQrrw==",
+      "deprecated": "Deprecated due to three.js version incompatibility. Please use v0.8.0, instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.151.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -1556,6 +2310,36 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -1568,6 +2352,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -1621,12 +2442,85 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/simple-expenses/package.json
+++ b/simple-expenses/package.json
@@ -9,14 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@react-three/drei": "^9.122.0",
+    "@react-three/fiber": "^8.18.0",
+    "framer-motion": "^11.18.2",
     "next": "14.2.18",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@types/node": "^22.9.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@types/three": "^0.184.0",
     "autoprefixer": "^10.4.20",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",

--- a/simple-expenses/public/icon.svg
+++ b/simple-expenses/public/icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0ea5e9"/>
+      <stop offset="100%" stop-color="#a855f7"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#g)"/>
+  <g fill="none" stroke="#fff" stroke-width="32" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M128 168h256"/>
+    <path d="M128 256h256"/>
+    <path d="M128 344h160"/>
+  </g>
+  <circle cx="376" cy="344" r="40" fill="#fff"/>
+  <text x="376" y="358" text-anchor="middle" font-family="Inter, system-ui, sans-serif" font-size="44" font-weight="700" fill="#0f172a">€</text>
+</svg>

--- a/simple-expenses/public/manifest.webmanifest
+++ b/simple-expenses/public/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Simple Expenses",
+  "short_name": "Despesas",
+  "description": "Gestão simples de despesas em várias contas e cartões",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0f172a",
+  "theme_color": "#0f172a",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
Continuação do trabalho na app `simple-expenses/` (PR #81 trouxe a versão inicial). Esta PR adiciona dois commits:

## `39e49e7` — Drop balances + 3D twist
- Remove `initialBalance` do tipo `Account`, formulário e cálculos. Dashboard e página de Contas mostram **total acumulado de despesas** em vez de saldos.
- Cenas 3D via `@react-three/fiber` + `@react-three/drei`, lazy-loaded com `next/dynamic`:
  - **HeroScene**: icosaedro central com `MeshDistortMaterial` + formas a orbitar (uma por conta, com a cor da conta).
  - **CategoryBars3D**: barras 3D animadas para totais mensais por categoria, com auto-rotate.
- Micro-interacções com `framer-motion`: tilt nos cards, flip 3D ao editar, entrada escalonada nas listas.
- **Burst** de partículas (rotateX/Y/Z) ao guardar uma despesa.

## `51695e6` — Mobile-friendly
- **Bottom tab bar** fixa em mobile (Resumo / Contas / Despesas / Definições) com ícones SVG e `safe-area-inset-bottom`. Top NavLinks passa a `md:flex`.
- **Header sticky** com `safe-area-inset-top`.
- **FABs** circulares "+ Despesa" / "+ Conta" em mobile (escondidos em desktop).
- Tap targets ≥44px, `text-base` em inputs em mobile (evita zoom iOS), `active:scale`, `touch-action: manipulation`, hit areas alargadas em editar/apagar.
- 3D `Canvas` com `dpr=[1, 1.5]` + `powerPreference: low-power`.
- **PWA**: `manifest.webmanifest` (standalone), theme-color light/dark, `apple-web-app capable`, `viewportFit: cover`, ícone SVG.

## Test plan

- [ ] `cd simple-expenses && npm install && npm run build` (já validado: 4 páginas estáticas, First Load JS 87.4 kB shared)
- [ ] `npm run dev` e verificar em desktop: hero 3D, gráfico 3D de categorias, flip ao editar conta, burst ao guardar despesa
- [ ] Verificar em mobile (DevTools responsive ≤768px): bottom tab bar, FAB visível, header não sobrepõe conteúdo, 3D fluido
- [ ] Adicionar ao Home Screen no iOS/Android e abrir em standalone

https://claude.ai/code/session_01T6T1EmgAshS2R754wuyARr

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6T1EmgAshS2R754wuyARr)_