### PR TITLE
Recurring expenses (daily/weekly/monthly/yearly) with optional end date

### DIFF
--- a/simple-expenses/app/accounts/page.tsx
+++ b/simple-expenses/app/accounts/page.tsx
@@ -7,6 +7,7 @@ import { AccountForm } from "@/components/AccountForm";
 import { useAppData, accountActions } from "@/lib/storage";
 import { formatMoney } from "@/lib/format";
 import { ACCOUNT_TYPE_LABELS } from "@/lib/types";
+import { expandExpenses, todayStartOfDay } from "@/lib/recurrence";
 
 export default function AccountsPage() {
   return (
@@ -22,9 +23,27 @@ function Accounts() {
   const [editingId, setEditingId] = useState<string | null>(null);
 
   const totals = useMemo(() => {
+    const occurrences = expandExpenses(
+      expenses,
+      new Date(2000, 0, 1),
+      todayStartOfDay(),
+    );
     const map = new Map<string, number>();
-    for (const e of expenses) {
+    for (const e of occurrences) {
       map.set(e.accountId, (map.get(e.accountId) ?? 0) + e.amount);
+    }
+    return map;
+  }, [expenses]);
+
+  const counts = useMemo(() => {
+    const occurrences = expandExpenses(
+      expenses,
+      new Date(2000, 0, 1),
+      todayStartOfDay(),
+    );
+    const map = new Map<string, number>();
+    for (const e of occurrences) {
+      map.set(e.accountId, (map.get(e.accountId) ?? 0) + 1);
     }
     return map;
   }, [expenses]);
@@ -90,7 +109,7 @@ function Accounts() {
       <div className="grid gap-3 sm:grid-cols-2">
         {accounts.map((a, i) => {
           const isEditing = editingId === a.id;
-          const count = expenses.filter((e) => e.accountId === a.id).length;
+          const count = counts.get(a.id) ?? 0;
           const total = totals.get(a.id) ?? 0;
           return (
             <motion.div

--- a/simple-expenses/app/expenses/page.tsx
+++ b/simple-expenses/app/expenses/page.tsx
@@ -8,6 +8,13 @@ import { Burst } from "@/components/Burst";
 import { useAppData, expenseActions } from "@/lib/storage";
 import { formatDate, formatMoney, monthKey } from "@/lib/format";
 import { DEFAULT_CATEGORIES } from "@/lib/types";
+import {
+  expandExpenses,
+  getRealId,
+  parseIso,
+  recurrenceLabel,
+  todayStartOfDay,
+} from "@/lib/recurrence";
 
 export default function ExpensesPage() {
   return (
@@ -27,23 +34,45 @@ function Expenses() {
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [monthFilter, setMonthFilter] = useState<string>("all");
 
-  const months = useMemo(() => {
-    const set = new Set(expenses.map((e) => monthKey(e.date)));
-    return [...set].sort().reverse();
+  const occurrences = useMemo(() => {
+    const today = todayStartOfDay();
+    const earliest = expenses.reduce<Date>((acc, e) => {
+      const d = parseIso(e.date);
+      return d < acc ? d : acc;
+    }, today);
+    const start = new Date(earliest);
+    start.setDate(start.getDate() - 1);
+    const end = new Date(today);
+    end.setMonth(end.getMonth() + 12);
+    return expandExpenses(expenses, start, end);
   }, [expenses]);
 
+  const months = useMemo(() => {
+    const set = new Set(occurrences.map((e) => monthKey(e.date)));
+    return [...set].sort().reverse();
+  }, [occurrences]);
+
   const filtered = useMemo(() => {
-    return expenses
+    return occurrences
       .filter((e) => accountFilter === "all" || e.accountId === accountFilter)
       .filter((e) => categoryFilter === "all" || e.category === categoryFilter)
       .filter((e) => monthFilter === "all" || monthKey(e.date) === monthFilter)
       .sort((a, b) => (a.date < b.date ? 1 : -1));
-  }, [expenses, accountFilter, categoryFilter, monthFilter]);
+  }, [occurrences, accountFilter, categoryFilter, monthFilter]);
 
   const total = filtered.reduce((s, e) => s + e.amount, 0);
 
-  function remove(id: string, description: string) {
-    if (confirm(`Apagar "${description}"?`)) expenseActions.remove(id);
+  const editingExpense = useMemo(() => {
+    if (!editingId) return undefined;
+    const realId = getRealId(editingId);
+    return expenses.find((e) => e.id === realId);
+  }, [editingId, expenses]);
+
+  function remove(virtualId: string, description: string, recurring: boolean) {
+    const message = recurring
+      ? `Apagar a série completa de "${description}"? Todas as ocorrências (passadas e futuras) serão removidas.`
+      : `Apagar "${description}"?`;
+    if (confirm(message)) expenseActions.remove(getRealId(virtualId));
   }
 
   return (
@@ -164,7 +193,9 @@ function Expenses() {
                 {filtered.map((e, i) => {
                   const account = accounts.find((a) => a.id === e.accountId);
                   const isEditing = editingId === e.id;
-                  if (isEditing) {
+                  const recurring = !!e.recurrence;
+                  const future = parseIso(e.date) > todayStartOfDay();
+                  if (isEditing && editingExpense) {
                     return (
                       <motion.div
                         key={e.id}
@@ -175,9 +206,15 @@ function Expenses() {
                         style={{ transformPerspective: 900 }}
                         className="py-3 first:pt-0 last:pb-0"
                       >
+                        {recurring && (
+                          <p className="mb-3 text-xs text-ink-600 dark:text-ink-400 bg-ink-100 dark:bg-ink-700 rounded-md px-3 py-2">
+                            ↻ A editar a série inteira — alterações aplicam-se
+                            a todas as ocorrências.
+                          </p>
+                        )}
                         <ExpenseForm
                           accounts={accounts}
-                          expense={e}
+                          expense={editingExpense}
                           onDone={() => setEditingId(null)}
                           onCancel={() => setEditingId(null)}
                         />
@@ -203,7 +240,24 @@ function Expenses() {
                         style={{ backgroundColor: account?.color ?? "#94a3b8" }}
                       />
                       <div className="flex-1 min-w-0">
-                        <div className="font-medium truncate">{e.description}</div>
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <span className="font-medium truncate">
+                            {e.description}
+                          </span>
+                          {recurring && (
+                            <span
+                              className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-medium px-1.5 py-0.5 rounded bg-ink-900 text-white dark:bg-ink-100 dark:text-ink-900"
+                              title={recurrenceLabel(e) ?? ""}
+                            >
+                              ↻ {recurrenceLabel(e)}
+                            </span>
+                          )}
+                          {future && (
+                            <span className="text-[10px] uppercase tracking-wide text-ink-600 dark:text-ink-400">
+                              futura
+                            </span>
+                          )}
+                        </div>
                         <div className="text-xs text-ink-600 dark:text-ink-400">
                           {account?.name ?? "—"} · {e.category} ·{" "}
                           {formatDate(e.date)}
@@ -227,7 +281,9 @@ function Expenses() {
                           </button>
                           <button
                             className="px-2 py-1 text-xs text-red-600 hover:text-red-700 rounded touch-manipulation"
-                            onClick={() => remove(e.id, e.description)}
+                            onClick={() =>
+                              remove(e.id, e.description, recurring)
+                            }
                           >
                             apagar
                           </button>

--- a/simple-expenses/app/page.tsx
+++ b/simple-expenses/app/page.tsx
@@ -7,6 +7,12 @@ import { useMemo } from "react";
 import { ClientOnly } from "@/components/ClientOnly";
 import { useAppData } from "@/lib/storage";
 import { formatMoney, monthKey, monthLabel } from "@/lib/format";
+import {
+  endOfMonth,
+  expandExpenses,
+  startOfMonth,
+  todayStartOfDay,
+} from "@/lib/recurrence";
 
 const HeroScene = dynamic(
   () => import("@/components/three/HeroScene").then((m) => m.HeroScene),
@@ -31,9 +37,19 @@ function Dashboard() {
   const { accounts, expenses } = useAppData();
 
   const thisMonth = monthKey(new Date().toISOString());
-  const monthExpenses = expenses.filter((e) => monthKey(e.date) === thisMonth);
+
+  const monthExpenses = useMemo(() => {
+    const today = todayStartOfDay();
+    return expandExpenses(expenses, startOfMonth(today), endOfMonth(today));
+  }, [expenses]);
+
+  const pastOccurrences = useMemo(() => {
+    const start = new Date(2000, 0, 1);
+    return expandExpenses(expenses, start, todayStartOfDay());
+  }, [expenses]);
+
   const monthTotal = monthExpenses.reduce((s, e) => s + e.amount, 0);
-  const totalAll = expenses.reduce((s, e) => s + e.amount, 0);
+  const totalAll = pastOccurrences.reduce((s, e) => s + e.amount, 0);
 
   const byCategory = useMemo(() => {
     const map = new Map<string, number>();
@@ -51,7 +67,7 @@ function Dashboard() {
     return map;
   }, [monthExpenses]);
 
-  const recent = [...expenses]
+  const recent = [...pastOccurrences]
     .sort((a, b) => (a.date < b.date ? 1 : -1))
     .slice(0, 5);
 
@@ -104,7 +120,7 @@ function Dashboard() {
         <div className="grid gap-3 sm:grid-cols-2">
           {accounts.map((a, i) => {
             const monthSpent = byAccountMonth.get(a.id) ?? 0;
-            const total = expenses
+            const total = pastOccurrences
               .filter((e) => e.accountId === a.id)
               .reduce((s, e) => s + e.amount, 0);
             return (

--- a/simple-expenses/components/ExpenseForm.tsx
+++ b/simple-expenses/components/ExpenseForm.tsx
@@ -5,8 +5,11 @@ import { expenseActions } from "@/lib/storage";
 import { todayIso } from "@/lib/format";
 import {
   DEFAULT_CATEGORIES,
+  FREQUENCY_LABELS,
   type Account,
   type Expense,
+  type Frequency,
+  type Recurrence,
 } from "@/lib/types";
 
 interface Props {
@@ -34,10 +37,26 @@ export function ExpenseForm({
   );
   const [date, setDate] = useState(expense?.date ?? todayIso());
   const [notes, setNotes] = useState(expense?.notes ?? "");
+  const [isRecurring, setIsRecurring] = useState(!!expense?.recurrence);
+  const [frequency, setFrequency] = useState<Frequency>(
+    expense?.recurrence?.frequency ?? "monthly",
+  );
+  const [interval, setIntervalValue] = useState(
+    (expense?.recurrence?.interval ?? 1).toString(),
+  );
+  const [hasEndDate, setHasEndDate] = useState(!!expense?.recurrence?.endDate);
+  const [endDate, setEndDate] = useState(expense?.recurrence?.endDate ?? "");
 
   function submit(e: React.FormEvent) {
     e.preventDefault();
     if (!accountId) return;
+    const recurrence: Recurrence | undefined = isRecurring
+      ? {
+          frequency,
+          interval: Math.max(1, Number(interval) || 1),
+          endDate: hasEndDate && endDate ? endDate : undefined,
+        }
+      : undefined;
     const payload = {
       accountId,
       description: description.trim(),
@@ -45,6 +64,7 @@ export function ExpenseForm({
       category,
       date,
       notes: notes.trim() || undefined,
+      recurrence,
     };
     if (!payload.description || payload.amount <= 0) return;
     if (expense) {
@@ -83,13 +103,14 @@ export function ExpenseForm({
             type="number"
             step="0.01"
             min="0"
+            inputMode="decimal"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
             required
           />
         </div>
         <div>
-          <label className="label">Data</label>
+          <label className="label">{isRecurring ? "Início" : "Data"}</label>
           <input
             className="input"
             type="date"
@@ -138,6 +159,93 @@ export function ExpenseForm({
           onChange={(e) => setNotes(e.target.value)}
         />
       </div>
+
+      <div className="rounded-lg border border-ink-200 dark:border-ink-700 p-3 space-y-3">
+        <label className="flex items-center gap-2 cursor-pointer touch-manipulation">
+          <input
+            type="checkbox"
+            checked={isRecurring}
+            onChange={(e) => setIsRecurring(e.target.checked)}
+            className="h-5 w-5 rounded border-ink-300 dark:bg-ink-800"
+          />
+          <span className="text-sm font-medium">
+            Repetir esta despesa
+          </span>
+        </label>
+        {isRecurring && (
+          <div className="space-y-3 pt-1">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="label">Frequência</label>
+                <select
+                  className="select"
+                  value={frequency}
+                  onChange={(ev) => setFrequency(ev.target.value as Frequency)}
+                >
+                  {Object.entries(FREQUENCY_LABELS).map(([k, v]) => (
+                    <option key={k} value={k}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="label">A cada</label>
+                <input
+                  className="input"
+                  type="number"
+                  min="1"
+                  inputMode="numeric"
+                  value={interval}
+                  onChange={(ev) => setIntervalValue(ev.target.value)}
+                />
+              </div>
+            </div>
+            <div>
+              <label className="label">Termina</label>
+              <div className="flex gap-2 mb-2">
+                <button
+                  type="button"
+                  className={
+                    "btn flex-1 " +
+                    (!hasEndDate
+                      ? "bg-ink-900 text-white"
+                      : "border border-ink-200 dark:border-ink-600 text-ink-600 dark:text-ink-200")
+                  }
+                  onClick={() => setHasEndDate(false)}
+                >
+                  Sempre
+                </button>
+                <button
+                  type="button"
+                  className={
+                    "btn flex-1 " +
+                    (hasEndDate
+                      ? "bg-ink-900 text-white"
+                      : "border border-ink-200 dark:border-ink-600 text-ink-600 dark:text-ink-200")
+                  }
+                  onClick={() => setHasEndDate(true)}
+                >
+                  Numa data
+                </button>
+              </div>
+              {hasEndDate && (
+                <input
+                  className="input"
+                  type="date"
+                  value={endDate}
+                  min={date}
+                  onChange={(ev) => setEndDate(ev.target.value)}
+                />
+              )}
+            </div>
+            <p className="text-xs text-ink-600 dark:text-ink-400">
+              Editar ou apagar uma ocorrência aplica-se a toda a série.
+            </p>
+          </div>
+        )}
+      </div>
+
       <div className="flex gap-2 pt-2">
         <button type="submit" className="btn-primary">
           {expense ? "Guardar alterações" : "Adicionar despesa"}

--- a/simple-expenses/lib/recurrence.ts
+++ b/simple-expenses/lib/recurrence.ts
@@ -1,0 +1,118 @@
+import type { Expense, Frequency } from "./types";
+
+const VIRTUAL_SEP = "@";
+const MAX_OCCURRENCES = 600;
+
+export function parseIso(iso: string): Date {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export function toIso(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function todayStartOfDay(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function startOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+export function endOfMonth(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+function addInterval(date: Date, freq: Frequency, n: number): Date {
+  const d = new Date(date);
+  switch (freq) {
+    case "daily":
+      d.setDate(d.getDate() + n);
+      break;
+    case "weekly":
+      d.setDate(d.getDate() + n * 7);
+      break;
+    case "monthly": {
+      const day = d.getDate();
+      d.setDate(1);
+      d.setMonth(d.getMonth() + n);
+      const lastDayOfMonth = new Date(
+        d.getFullYear(),
+        d.getMonth() + 1,
+        0,
+      ).getDate();
+      d.setDate(Math.min(day, lastDayOfMonth));
+      break;
+    }
+    case "yearly":
+      d.setFullYear(d.getFullYear() + n);
+      break;
+  }
+  return d;
+}
+
+export function expandExpenses(
+  expenses: Expense[],
+  rangeStart: Date,
+  rangeEnd: Date,
+): Expense[] {
+  const out: Expense[] = [];
+  for (const e of expenses) {
+    const startDate = parseIso(e.date);
+    if (!e.recurrence) {
+      if (startDate >= rangeStart && startDate <= rangeEnd) out.push(e);
+      continue;
+    }
+    const interval = Math.max(1, e.recurrence.interval || 1);
+    const freq = e.recurrence.frequency;
+    const ruleEnd = e.recurrence.endDate
+      ? parseIso(e.recurrence.endDate)
+      : null;
+    const hardEnd = ruleEnd && ruleEnd < rangeEnd ? ruleEnd : rangeEnd;
+    let current = startDate;
+    let safety = 0;
+    while (current <= hardEnd && safety < MAX_OCCURRENCES) {
+      if (current >= rangeStart) {
+        const iso = toIso(current);
+        out.push({
+          ...e,
+          id: `${e.id}${VIRTUAL_SEP}${iso}`,
+          date: iso,
+        });
+      }
+      current = addInterval(current, freq, interval);
+      safety++;
+    }
+  }
+  return out;
+}
+
+export function getRealId(id: string): string {
+  const at = id.indexOf(VIRTUAL_SEP);
+  return at === -1 ? id : id.slice(0, at);
+}
+
+export function isVirtualOccurrence(id: string): boolean {
+  return id.includes(VIRTUAL_SEP);
+}
+
+export function recurrenceLabel(e: Expense): string | null {
+  if (!e.recurrence) return null;
+  const labels: Record<Frequency, string> = {
+    daily: "dia",
+    weekly: "semana",
+    monthly: "mês",
+    yearly: "ano",
+  };
+  const n = Math.max(1, e.recurrence.interval || 1);
+  const unit = labels[e.recurrence.frequency];
+  const every = n === 1 ? `cada ${unit}` : `cada ${n} ${unit}s`;
+  if (e.recurrence.endDate) return `${every}, até ${e.recurrence.endDate}`;
+  return `${every}`;
+}

--- a/simple-expenses/lib/types.ts
+++ b/simple-expenses/lib/types.ts
@@ -1,5 +1,13 @@
 export type AccountType = "checking" | "savings" | "credit" | "debit" | "cash";
 
+export type Frequency = "daily" | "weekly" | "monthly" | "yearly";
+
+export interface Recurrence {
+  frequency: Frequency;
+  interval: number;
+  endDate?: string;
+}
+
 export interface Account {
   id: string;
   name: string;
@@ -17,6 +25,7 @@ export interface Expense {
   category: string;
   date: string;
   notes?: string;
+  recurrence?: Recurrence;
   createdAt: string;
 }
 
@@ -37,6 +46,13 @@ export const DEFAULT_CATEGORIES = [
   "Subscrições",
   "Outros",
 ] as const;
+
+export const FREQUENCY_LABELS: Record<Frequency, string> = {
+  daily: "Diariamente",
+  weekly: "Semanalmente",
+  monthly: "Mensalmente",
+  yearly: "Anualmente",
+};
 
 export const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
   checking: "Conta corrente",


### PR DESCRIPTION
## Summary

Cada despesa pode agora repetir-se diariamente / semanalmente / mensalmente / anualmente, com fim numa data específica ou **para sempre**. A regra é guardada uma única vez na despesa-mãe; as ocorrências são geradas em runtime ao mostrar — eficiente e suporta séries infinitas.

## Detalhes

- Novos tipos `Recurrence` / `Frequency` e campo opcional `recurrence` em `Expense`. Despesas one-time pré-existentes continuam a funcionar sem mudanças.
- `lib/recurrence.ts` com `expandExpenses(range)`, math de datas que faz clamp do dia ao último dia do mês (ex: dia 31 → 28/29/30 quando não existe), e ids virtuais `parent@YYYY-MM-DD` para ocorrências.
- `ExpenseForm` ganha secção "Repetir esta despesa" com frequência, intervalo (a cada N) e dois botões para terminar em **Sempre** ou **Numa data**.
- Lista de Despesas:
  - Badge `↻ cada mês` (ou similar) em itens recorrentes.
  - Etiqueta `futura` em ocorrências posteriores a hoje (úteis para preview de contas).
  - Filtro por mês mostra ocorrências passadas e futuras desse mês.
  - Editar/apagar uma ocorrência resolve para a regra-mãe; delete pede confirmação explícita ("Apagar série completa?").
- Dashboard: total do mês atual inclui ocorrências futuras desse mês; total acumulado e despesas recentes só contam passado/hoje.
- Página de Contas: total e contagem usam ocorrências passadas reais.

## Test plan

- [ ] `cd simple-expenses && npm run build` (validado: First Load JS 87.4 kB shared, dashboard 4.39 kB / expenses 4.16 kB)
- [ ] Criar despesa "Renda" em `2026-05-01`, mensal, sem fim → aparece todos os 1ºs do mês passados e nos próximos 12 meses; total deste mês inclui-a mesmo se ainda for futura
- [ ] Criar despesa semanal "Café", a cada 1 semana, até `2026-12-31` → ocorrências param na data limite
- [ ] Editar uma ocorrência futura → toda a série é actualizada (mensagem de aviso visível)
- [ ] Apagar uma ocorrência recorrente → confirma "apagar série completa", todas as ocorrências desaparecem
- [ ] Despesa one-time antiga continua a funcionar (carregar via "Importar JSON")

https://claude.ai/code/session_01T6T1EmgAshS2R754wuyARr

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6T1EmgAshS2R754wuyARr)_